### PR TITLE
Confirm that doesNotThrow doesn't freak out

### DIFF
--- a/test/meta-test.js
+++ b/test/meta-test.js
@@ -21,6 +21,7 @@ test("meta test", { skip: false }, function (t) {
   t.notOk(NaN, "NaN is notOk")
   t.notOk("", "empty string is notOk")
   t.throws(thr0w, "Thrower throws");
+  t.doesNotThrow(noop, "noop does not throw");
 
   // a few failures.
   t.ifError(new Error("this is an error"))
@@ -28,6 +29,7 @@ test("meta test", { skip: false }, function (t) {
   t.ok(false, "false is not ok")
   t.notOk(true, "true is not not ok")
   t.throws(noop, "noop does not throw");
+  t.doesNotThrow(thr0w, "thrower does throw");
   t.end()
 
   function section2 () {
@@ -35,9 +37,9 @@ test("meta test", { skip: false }, function (t) {
     t.clear()
     t.ok(true, "sanity check")
     t.notOk(results.ok, "not ok")
-    t.equal(results.tests, 18, "total test count")
-    t.equal(results.passTotal, 13, "tests passed")
-    t.equal(results.fail, 5, "tests failed")
+    t.equal(results.tests, 20, "total test count")
+    t.equal(results.passTotal, 14, "tests passed")
+    t.equal(results.fail, 6, "tests failed")
     t.type(results.ok, "boolean", "ok is boolean")
     t.type(results.skip, "number", "skip is number")
     t.type(results, "Results", "results isa Results")

--- a/test/meta-test.js
+++ b/test/meta-test.js
@@ -3,10 +3,13 @@ var tap = require("../")
 
 test("meta test", { skip: false }, function (t) {
 
+  function thr0w() { throw new Error('raburt') }
+  function noop () {}
+
   // this also tests the ok/notOk functions
   t.once("end", section2)
   t.ok(true, "true is ok")
-  t.ok(function () {}, "function is ok")
+  t.ok(noop, "function is ok")
   t.ok({}, "object is ok")
   t.ok(t, "t is ok")
   t.ok(100, "number is ok")
@@ -17,12 +20,14 @@ test("meta test", { skip: false }, function (t) {
   t.notOk(undefined, "undefined is notOk")
   t.notOk(NaN, "NaN is notOk")
   t.notOk("", "empty string is notOk")
+  t.throws(thr0w, "Thrower throws");
 
   // a few failures.
   t.ifError(new Error("this is an error"))
   t.ifError({ message: "this is a custom error" })
   t.ok(false, "false is not ok")
   t.notOk(true, "true is not not ok")
+  t.throws(noop, "noop does not throw");
   t.end()
 
   function section2 () {
@@ -30,9 +35,9 @@ test("meta test", { skip: false }, function (t) {
     t.clear()
     t.ok(true, "sanity check")
     t.notOk(results.ok, "not ok")
-    t.equal(results.tests, 16, "total test count")
-    t.equal(results.passTotal, 12, "tests passed")
-    t.equal(results.fail, 4, "tests failed")
+    t.equal(results.tests, 18, "total test count")
+    t.equal(results.passTotal, 13, "tests passed")
+    t.equal(results.fail, 5, "tests failed")
     t.type(results.ok, "boolean", "ok is boolean")
     t.type(results.skip, "number", "skip is number")
     t.type(results, "Results", "results isa Results")


### PR DESCRIPTION
Looks like tap-assert's `doesNotThrow` function is not behaving and (AFAICS) failing to return what tap-results wants to see.

If you pull my commit 0546b08 from tap-assert, then these tests will confirm that it is working.
