### PR TITLE
Show syntax errors (stderr).

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -24,6 +24,10 @@ if (process.env.TAP || process.env.TAP_DIAG) {
       console.log("    " + TapProducer.encode(details.list)
                   .split(/\n/).join("\n    "))
     }
+    if (results.stderr && details.ok && details.tests.pass === 0) {
+      // perhaps a compilation error or something else failed...
+      console.error(results.stderr)
+    }
   })
   r.on("end", function () {
     //console.log(r)


### PR DESCRIPTION
Not sure if this is the best way to do it, but this will show stderr when node finds syntax-errors in the test-script.
Should fix #4
