### PR TITLE
add -d, --debug option to pipe the test's stderr

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 
-var argv = process.argv.slice(2)
-  , path = require("path")
+var path = require("path")
   , Runner = require("tap-runner")
-  , r = new Runner(argv, null)
   , TapProducer = require("tap-producer")
-
+  , opts = require('nopt')({d: Boolean}, {d: ['--debug']}, process.argv, 2)
+  , argv = opts.argv.remain 
+  , r = new Runner(argv, null)
+ 
 if (process.env.TAP || process.env.TAP_DIAG) {
   r.pipe(process.stdout)
 } else {
+  if(opts.debug)
+    r.on('child_process', function (cp) {
+      cp.stderr.pipe(process.stderr, {end: false})
+    })
   r.on("file", function (file, results, details) {
     var s = (details.ok ? "" : "not ") + "ok "+results.name
       , n = details.pass + "/" + details.testsTotal

--- a/example/test/test-example.js
+++ b/example/test/test-example.js
@@ -15,6 +15,7 @@ test("validate constants", function (t) {
   t.equal(math.E, 2.718281828459045, "e")
   t.equal(math.LOG10E, 0.4342944819032518, "log 10 e")
   t.equal(math.SQRT2, 1.4142135623730951, "sqrt 2")
+  console.error('STDERR!!!!!')
   t.equal(math.SQRT1_2, 0.7071067811865476, "sqrt 1/2")
   t.equal(math.LN2, 0.6931471805599453, "ln2")
   t.end()

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   , "tap-results" : "0.x"
   , "tap-consumer" : "0.x"
   , "tap-producer" : "0.x"
+  , "nopt" : "1.0.x"
   , "inherits" : "*"
   , "yamlish" : "*"
   }


### PR DESCRIPTION
resolves this issue: https://github.com/isaacs/node-tap/issues/3

I've only supported piping stderr, because that is where debugging output should go. 
Maybe people will still want to show stdout, but then you would have to filter out what tap-consumer did not parse. 

And that isn't coming in on this sunday morning pull request.
