### PR TITLE
similar() and dissimilar() bug fix when `null` is used

### DIFF
--- a/lib/tap-assert.js
+++ b/lib/tap-assert.js
@@ -239,7 +239,8 @@ function dissimilar (a, b, message, extra) {
   if (extra && extra.skip) return assert.skip(message, extra)
   // test that a has all the fields in b
   message = message || "should be dissimilar"
-  return inequivalent(selectFields(a, b), b, message, extra)
+  a = a && selectFields(a, b); // Always send selectFields() usable params.
+  return inequivalent(a, b, message, extra)
 }
 assert.dissimilar = dissimilar
 syns.dissimilar = ["unsimilar"

--- a/lib/tap-assert.js
+++ b/lib/tap-assert.js
@@ -222,6 +222,10 @@ function similar (a, b, message, extra) {
   if (extra && extra.skip) return assert.skip(message, extra)
   // test that a has all the fields in b
   message = message || "should be similar"
+
+  var is_obj = assert(a, message, extra);
+  if(!is_obj.ok)
+    return is_obj;
   return equivalent(selectFields(a, b), b, message, extra)
 }
 assert.similar = similar

--- a/test/meta-test.js
+++ b/test/meta-test.js
@@ -24,6 +24,7 @@ test("meta test", { skip: false }, function (t) {
   t.doesNotThrow(noop, "noop does not throw");
   t.similar({foo:"bar", bar:"foo"}, {foo:"bar"}, "similar objects are ok");
   t.dissimilar({}, {mandatory:"value"}, "dissimilar objects are ok");
+  t.dissimilar(null, {}, "null is dissimilar from an object, even with no keys");
 
   // a few failures.
   t.ifError(new Error("this is an error"))
@@ -42,8 +43,8 @@ test("meta test", { skip: false }, function (t) {
     t.clear()
     t.ok(true, "sanity check")
     t.notOk(results.ok, "not ok")
-    t.equal(results.tests, 25, "total test count")
-    t.equal(results.passTotal, 16, "tests passed")
+    t.equal(results.tests, 26, "total test count")
+    t.equal(results.passTotal, 17, "tests passed")
     t.equal(results.fail, 9, "tests failed")
     t.type(results.ok, "boolean", "ok is boolean")
     t.type(results.skip, "number", "skip is number")

--- a/test/meta-test.js
+++ b/test/meta-test.js
@@ -30,7 +30,10 @@ test("meta test", { skip: false }, function (t) {
   t.ifError({ message: "this is a custom error" })
   t.ok(false, "false is not ok")
   t.notOk(true, "true is not not ok")
+  t.similar(null, {}, "Null is not similar to an object, even with no keys");
   t.throws(noop, "noop does not throw");
+  t.throws(noop, new Error("Whoops!"), "noop does not throw an Error");
+  t.throws(noop, {name:"MyError", message:"Whoops!"}, "noop does not throw a MyError");
   t.doesNotThrow(thr0w, "thrower does throw");
   t.end()
 
@@ -39,9 +42,9 @@ test("meta test", { skip: false }, function (t) {
     t.clear()
     t.ok(true, "sanity check")
     t.notOk(results.ok, "not ok")
-    t.equal(results.tests, 22, "total test count")
+    t.equal(results.tests, 25, "total test count")
     t.equal(results.passTotal, 16, "tests passed")
-    t.equal(results.fail, 6, "tests failed")
+    t.equal(results.fail, 9, "tests failed")
     t.type(results.ok, "boolean", "ok is boolean")
     t.type(results.skip, "number", "skip is number")
     t.type(results, "Results", "results isa Results")

--- a/test/meta-test.js
+++ b/test/meta-test.js
@@ -22,6 +22,8 @@ test("meta test", { skip: false }, function (t) {
   t.notOk("", "empty string is notOk")
   t.throws(thr0w, "Thrower throws");
   t.doesNotThrow(noop, "noop does not throw");
+  t.similar({foo:"bar", bar:"foo"}, {foo:"bar"}, "similar objects are ok");
+  t.dissimilar({}, {mandatory:"value"}, "dissimilar objects are ok");
 
   // a few failures.
   t.ifError(new Error("this is an error"))
@@ -37,8 +39,8 @@ test("meta test", { skip: false }, function (t) {
     t.clear()
     t.ok(true, "sanity check")
     t.notOk(results.ok, "not ok")
-    t.equal(results.tests, 20, "total test count")
-    t.equal(results.passTotal, 14, "tests passed")
+    t.equal(results.tests, 22, "total test count")
+    t.equal(results.passTotal, 16, "tests passed")
     t.equal(results.fail, 6, "tests failed")
     t.type(results.ok, "boolean", "ok is boolean")
     t.type(results.skip, "number", "skip is number")


### PR DESCRIPTION
Today `t.throws()` was giving me trouble. This is not the first time. Here is the problem:

```
var expected = {"name":"MyError", "message":"The message"};
t.throws(function() {
  console.log("I do not throw after all!")
}, expected);
```

Ultimately this is converted to `assert.similar(null, expected)` which calls `selectFields(null, expected)` which... wait for it... throws an exception trying to loop through `null`'.

These patches fix that. The only weird thing is that now `assert.similar()` runs two assertions internally. Not sure if that throws anything off such as the auto-incrementing `id` or whatever. All the tests still pass at least.

P.S. Thanks very much for merging all these into one repository!
