### PR TITLE
runner forwards stderr logging to stderr output

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -24,6 +24,7 @@ if (process.env.TAP || process.env.TAP_DIAG) {
       console.log("    " + TapProducer.encode(details.list)
                   .split(/\n/).join("\n    "))
     }
+    if (results.stderr) console.error(results.stderr); //show stderr if exists 
   })
   r.on("end", function () {
     //console.log(r)

--- a/test/runner-display-stderr-fixture1.js
+++ b/test/runner-display-stderr-fixture1.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/*
+  This file is a fixture for runner-display-stderr which runs bin/tap.js on this file
+  and confirms the output. Logs a few lines to stderr which the runner should output.
+ */
+
+var test = require('../').test;
+
+test('stderr logging', function (t) {
+  t.ok(true);
+  console.error('stderr output line1');
+  console.error('stderr output line2');
+  t.end();
+});

--- a/test/runner-display-stderr.js
+++ b/test/runner-display-stderr.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/*
+  Test invokes a child process to run the tap runner and confirms the output
+ */
+
+var test = require('../').test;
+var child_process = require('child_process');
+
+// prepare env options for our child process to run test
+var env = process.env;
+delete env.TAP;        //make sure these are clear for the cp exec
+delete env.TAP_DIAG;   //make sure these are clear for the cp exec
+delete env.TAP_NODIAG; //make sure these are clear for the cp exec
+var options = { env: env, cwd: __dirname };
+
+test('runner forwards stderr from tests to stderr', function (t) {
+  t.plan(2);
+  var cmd = '../bin/tap.js ./runner-display-stderr-fixture1.js';
+  child_process.exec(cmd, options, function (err, stdout, stderr) {
+    t.ok(stderr.match(/stderr output line1/), 'should contain stderr line1');
+    t.ok(stderr.match(/stderr output line2/), 'should contain stderr line2');
+    t.end();
+  });
+});


### PR DESCRIPTION
If a user logs to stderr (like console.error) from code or a test,
tap runner should forward this on to the tap runner stderr output.

Test included.
