### PR TITLE
Fix #33

### DIFF
--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -143,13 +143,17 @@ Runner.prototype.runFiles = function (files, dir, cb) {
         }
 
         var cmd = f, args = [], env = {}
-
         if (path.extname(f) === ".js") {
           cmd = "node"
           args = [fileName]
         } else if (path.extname(f) === ".coffee") {
           cmd = "coffee"
           args = [fileName]
+        } else if ((st.mode & 0111) == 0) {
+            // Execute bit not set for user/group/other and isn't js/cs
+            // TODO: more advanced permissions checking ("can I execute?"
+            // instead of "can it be executed?"
+            return cb()
         }
 
         if (st.isDirectory()) {

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -149,11 +149,19 @@ Runner.prototype.runFiles = function (files, dir, cb) {
         } else if (path.extname(f) === ".coffee") {
           cmd = "coffee"
           args = [fileName]
-        } else if ((st.mode & 0111) == 0) {
-            // Execute bit not set for user/group/other and isn't js/cs
-            // TODO: more advanced permissions checking ("can I execute?"
-            // instead of "can it be executed?"
+        } else {
+          // Check if file is executable
+          if ((st.mode & 0100) && process.getuid) {
+            if (process.getuid() != st.uid) {
+              return cb()
+            }
+          } else if ((st.mode & 0010) && process.getgid) {
+            if (process.getgid() != st.gid) {
+              return cb()
+            }
+          } else if ((st.mode & 0001) == 0) {
             return cb()
+          }
         }
 
         if (st.isDirectory()) {

--- a/test/executed.sh
+++ b/test/executed.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "1..1"
+echo "ok 1 File with executable bit should be executed"

--- a/test/not-executed.sh
+++ b/test/not-executed.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "1..1"
+echo "not ok 1 File without executable bit should not be run"


### PR DESCRIPTION
tap-runner.js no longer tries to execute scripts if they don't have the executable bit set for anyone. Is kinda dirty as it doesn't check if the user can execute the file. I'll add that in if you want, I just don't have time right now.

Adds two tests, executed.sh and not-executed.sh. not-executed.sh will always fail, if it is run.
