### PR TITLE
Added support for -gc and --expose-gc

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -15,6 +15,7 @@ var argv = process.argv.slice(2)
     , version: Boolean
     , tap: Boolean
     , timeout: Number
+    , gc: Boolean
     }
 
   , shorthands =
@@ -24,6 +25,8 @@ var argv = process.argv.slice(2)
     , dd: ["--stderr", "--tap"]
     // debugging 3: show stderr, tap, AND always show diagnostics.
     , ddd: ["--stderr", "--tap", "--diag"]
+    , "expose-gc": ["--gc"]
+    , g: ["--gc"]
     , e: ["--stderr"]
     , t: ["--timeout"]
     , o: ["--tap"]
@@ -40,6 +43,7 @@ var argv = process.argv.slice(2)
     , tap: process.env.TAP
     , diag: process.env.TAP_DIAG
     , timeout: +process.env.TAP_TIMEOUT || 30
+    , gc: false
     , version: false
     , help: false }
 
@@ -64,9 +68,10 @@ Options:
     --tap       Print raw tap output.
     --diag      Print diagnostic output for passed tests, as well as failed.
                 (Implies --tap)
+    --gc        Expose the garbage collector to tests.
     --timeout   Maximum time to wait for a subtest, in seconds. Default: 30
-    --version   Print the version of node tap
-    --help      Print this help
+    --version   Print the version of node tap.
+    --help      Print this help.
 
 Please report bugs!  https://github.com/isaacs/node-tap/issues
 

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -140,12 +140,16 @@ Runner.prototype.runFiles = function (files, dir, cb) {
 
         var cmd = f, args = [], env = {}
 
+        if (self.options.gc) {
+          args.push("--expose-gc")
+        }
+
         if (path.extname(f) === ".js") {
           cmd = "node"
-          args = [fileName]
+          args.push(fileName)
         } else if (path.extname(f) === ".coffee") {
           cmd = "coffee"
-          args = [fileName]
+          args.push(fileName)
         }
 
         if (st.isDirectory()) {
@@ -158,13 +162,12 @@ Runner.prototype.runFiles = function (files, dir, cb) {
             , tmpBaseName = path.basename(f, path.extname(f))
                           + ".with-coverage." + process.pid + path.extname(f)
             , tmpFname = path.resolve(path.dirname(f), tmpBaseName)
-            , i
 
           fs.writeFileSync(tmpFname, fcontents, "utf8")
-          args = [tmpFname]
+          args.splice(-1, 1, tmpFname)
         }
 
-        for (i in process.env) {
+        for (var i in process.env) {
           env[i] = process.env[i]
         }
         env.TAP = 1

--- a/test/expose-gc-test.js
+++ b/test/expose-gc-test.js
@@ -1,0 +1,46 @@
+var tap = require("../")
+  , fs = require("fs")
+  , cp = require("child_process")
+
+fs.writeFileSync("gc-script.js", "console.log(!!global.gc)", "utf8")
+
+tap.test("gc test when the gc isn't there", function (t) {
+  console.error("gc test")
+  t.plan(1)
+  console.error("t.plan="+t._plan)
+
+  cp.exec("../bin/tap.js ./gc-script", function (err, stdo, stde) {
+    console.error("assert gc does not exist")
+    t.ok("false", stdo)
+  })
+})
+
+tap.test("gc test when the gc should be there", function (t) {
+  console.error("gc test")
+  t.plan(2)
+  console.error("t.plan="+t._plan)
+
+  t.test("test for gc using --gc", function (t) {
+    console.error("gc test using --gc")
+    t.plan(1)
+    console.error("t.plan="+t._plan)
+
+    cp.exec("../bin/tap.js --gc ./gc-script", function (err, stdo, stde) {
+      console.error("assert gc exists")
+      t.ok("true", stdo)
+    })
+  })
+
+  t.test("test for gc using --expose-gc", function (t) {
+    console.error("gc test using --expose-gc")
+    t.plan(1)
+    console.error("t.plan="+t._plan)
+
+    cp.exec("../bin/tap.js --expose-gc ./gc-script", function (err, stdo) {
+      console.error("assert gc exists")
+      t.ok("true", stdo)
+    })
+  })
+})
+
+fs.unlinkSync("gc-script.js");


### PR DESCRIPTION
- Exposes the `gc()` function in tap tests
- Added a test "expose-gc-test.js" to back this up

All tests pass.
