### PR TITLE
Child test name output fix

### DIFF
--- a/lib/tap-browser-harness.js
+++ b/lib/tap-browser-harness.js
@@ -30,7 +30,10 @@ function BrowserHarness (outPipe) {
     //console.error(child.results)
     // write out the stuff for this child.
     //console.error("child.conf", child.conf)
-    output.write(child.conf.name || "(unnamed test)")
+    
+    // Test names are added to the results by the Harness (tap-harness)
+    // output.write(child.conf.name || "(unnamed test)")
+    
     // maybe write some other stuff about the number of tests in this
     // thing, etc.  I dunno.
     //console.error("child results", child.results)

--- a/lib/tap-global-harness.js
+++ b/lib/tap-global-harness.js
@@ -34,7 +34,10 @@ function GlobalHarness () {
     //console.error(child.results)
     // write out the stuff for this child.
     //console.error("child.conf", child.conf)
-    output.write(child.conf.name || "(unnamed test)")
+    
+    // Test names are added to the results by the Harness (tap-harness)
+    // output.write(child.conf.name || "(unnamed test)")
+    
     // maybe write some other stuff about the number of tests in this
     // thing, etc.  I dunno.
     //console.error("child results", child.results)

--- a/lib/tap-harness.js
+++ b/lib/tap-harness.js
@@ -140,6 +140,8 @@ Harness.prototype.childEnd = function (child) {
   this._testCount ++
   this._planSum += child._plan
   //console.error("adding set of child.results")
+
+  this.results.add(child.conf.name || "(unnamed test)")
   this.results.addSet(child.results)
   this.emit("childEnd", child)
   // was this planned?

--- a/test/output-childtest-description.js
+++ b/test/output-childtest-description.js
@@ -1,0 +1,50 @@
+var tap  =  require("../")
+  , fs   =  require("fs")
+  , path =  require('path')
+  , cp   =  require("child_process")
+  , nestedTests = 
+      [ "var test = require('..').test"
+      , "test('parent test description', function (t) {"
+      , " t.plan(2)"
+      , " t.ok(true, 'test in parent')"
+      , " t.test('child test description', function (t) {"
+      , "    t.plan(1)"
+      , "    t.ok(true, 'test in child')  "
+      , " })"
+      , "})"
+      ].join("\n")
+  , nestedTestsFile = path.join(__dirname, "nested-tests-fixture.js")
+
+fs.writeFileSync(nestedTestsFile, nestedTests, "utf8")
+console.log(nestedTestsFile);
+
+tap.test("nested tests, parent and child pass", function (t) {
+  /*
+   * Ensure the output includes the following lines in the right order:
+   * '# parent test description'
+   *   'ok 1 test in parent'
+   * '# child test description'
+   *   'ok 2 test in child'
+   */
+
+  t.plan(5)
+
+  cp.exec("node " + nestedTestsFile, function (err, stdo, stde) {
+    var lines = stdo.split("\n")
+      , parentDes =  lines.indexOf("# parent test description")
+      , parentRes =  lines.indexOf("ok 1 test in parent")
+      , childDes  =  lines.indexOf("# child test description")
+      , childRes  =  lines.indexOf("ok 2 test in child")
+
+    t.notEqual(parentDes, -1, "outputs parent description")
+    t.notEqual(childDes, -1, "outputs child description")
+
+    t.ok(parentDes < parentRes ,  "outputs parent description before parent result")
+    t.ok(parentRes < childDes  ,  "outputs parent result before child description")
+    t.ok(childDes  < childRes  ,  "outputs child description before child result")
+
+    fs.unlinkSync(nestedTestsFile);
+    t.end()
+  })
+})
+


### PR DESCRIPTION
Fixes [issue #55 ](https://github.com/isaacs/node-tap/issues/55)

Main underlying reason is that "childEnd" raised by 'tap-harness' only triggers inside 'tap-global-harness' for parent tests.
This caused child test descriptions not being written to the output.

To fix it I added the test-names to the harness results directly.

I hope this is a viable solution.
All tests (including the one I created to expose the problem) pass.
