### PR TITLE
Adding `assert.notStrictEqual()` for 'assert' compatibility

### DIFF
--- a/lib/tap-assert.js
+++ b/lib/tap-assert.js
@@ -202,6 +202,7 @@ function inequal (a, b, message, extra) {
 assert.inequal = inequal
 syns.inequal = ["notEqual"
                ,"notEquals"
+               ,"notStrictEqual"
                ,"isNotEqual"
                ,"isNot"
                ,"not"


### PR DESCRIPTION
Although node-tap's `assert` is already somewhat incompatible with Node's 'assert' module (for instance, `assert.equal()` here uses threequality instead of coercive equality), the complete lack of `notStrictEqual` to match 'assert's might as well be fixed.
