### PR TITLE
Add -g flag to installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Default Usage:
 2. Put a bunch of test scripts in there.  If they're node programs, then
    they should be ".js".  Anything else is assumed to be some kind of shell
    script, which should have a shebang line.
-3. `npm install tap`
+3. `npm install tap -g`
 4. `tap ./test`
 
 The output will be TAP-compliant.


### PR DESCRIPTION
Installation instructions missing -g global installation flag.
'npm install tap' will not allow use of 'tap ./test'
- Unless I'm missing something.
