### PR TITLE
Call EventEmitter constructor in child classes.

### DIFF
--- a/lib/tap-harness.js
+++ b/lib/tap-harness.js
@@ -9,16 +9,20 @@
 // - "skip" in the test config obj should skip it.
 
 module.exports = Harness
-require("inherits")(Harness, require("events").EventEmitter)
 
 var Results = require("./tap-results")
   , TapProducer = require("./tap-producer")
   , assert = require("./tap-assert")
+  , EventEmitter = require("events").EventEmitter
+
+require("inherits")(Harness, EventEmitter)
 
 function Harness (Test) {
   if (!(this instanceof Harness)) return new Harness(Test)
 
   //console.error("Test in "+this.constructor.name, Test)
+
+  EventEmitter.call(this)
 
   this._Test = Test
   this._plan = null

--- a/lib/tap-results.js
+++ b/lib/tap-results.js
@@ -9,6 +9,7 @@ inherits(Results, EventEmitter)
 
 function Results (r) {
   //console.error("result constructor", r)
+  EventEmitter.call(this)
   this.ok = true
   this.addSet(r)
 }


### PR DESCRIPTION
Currently the `Harness` and `Results` classes inherit from `EventEmitter`,
but they do not call the `EventEmitter` constructor.

See joyent/node#4891.
