### PR TITLE
Pass debug and debug-brk flags to node for debugging Tap tests

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -16,6 +16,8 @@ var argv = process.argv.slice(2)
     , tap: Boolean
     , timeout: Number
     , gc: Boolean
+    , debug: Boolean
+    , "debug-brk": Boolean
     }
 
   , shorthands =
@@ -44,6 +46,8 @@ var argv = process.argv.slice(2)
     , diag: process.env.TAP_DIAG
     , timeout: +process.env.TAP_TIMEOUT || 30
     , gc: false
+    , debug: false
+    , "debug-brk": false
     , version: false
     , help: false }
 
@@ -64,14 +68,16 @@ Usage:
 
 Options:
 
-    --stderr    Print standard error output of tests to standard error.
-    --tap       Print raw tap output.
-    --diag      Print diagnostic output for passed tests, as well as failed.
-                (Implies --tap)
-    --gc        Expose the garbage collector to tests.
-    --timeout   Maximum time to wait for a subtest, in seconds. Default: 30
-    --version   Print the version of node tap.
-    --help      Print this help.
+    --stderr     Print standard error output of tests to standard error.
+    --tap        Print raw tap output.
+    --diag       Print diagnostic output for passed tests, as well as failed.
+                 (Implies --tap)
+    --gc         Expose the garbage collector to tests.
+    --timeout    Maximum time to wait for a subtest, in seconds. Default: 30
+    --debug      Pass the '--debug' flag to node for debugging
+    --debug-brk  Pass the '--debug-brk' flag to node for debugging
+    --version    Print the version of node tap.
+    --help       Print this help.
 
 Please report bugs!  https://github.com/isaacs/node-tap/issues
 

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -143,6 +143,17 @@ Runner.prototype.runFiles = function (files, dir, cb) {
   })
 }
 
+// set some default options for node debugging tests
+function setOptionsForDebug(self) {
+  // Note: we automatically increase the default timeout here. Yes the user can 
+  // specify --timeout to increase, but by default, 30 seconds is not a long time to debug your test.
+  self.options.timeout = 1000000; 
+            
+  // Note: we automatically turn on stderr so user can see the 'debugger listening on port' message.
+  // Without this it looks like tap has hung..
+  self.options.stderr = true;
+}
+
 function runFiles(self, files, dir, cb) {
   chain(files.map(function(f) {
     return function (cb) {
@@ -163,6 +174,14 @@ function runFiles(self, files, dir, cb) {
           cmd = "node"
           if (self.options.gc) {
             args.push("--expose-gc")
+          }
+          if (self.options.debug) {
+            args.push("--debug")
+            setOptionsForDebug(self)
+          }
+          if (self.options["debug-brk"]) {
+            args.push("--debug-brk")
+            setOptionsForDebug(self)
           }
           args.push(fileName)
         } else if (path.extname(f) === ".coffee") {

--- a/test/debug-test.js
+++ b/test/debug-test.js
@@ -1,0 +1,16 @@
+var tap = require("../")
+  , fs = require("fs")
+  , cp = require("child_process")
+  , util = require("util")
+
+tap.test("debug test", function (t) {
+  console.error("debug test")
+  t.plan(1)
+  console.error("t.plan="+t._plan)
+
+  cp.exec("../bin/tap.js --debug meta-test.js", function (err, stdo, stde) {
+    console.error(util.inspect(stde)) 
+    t.notEqual(stde.indexOf("debugger listening on port"), -1, "Should output debugger message")
+    t.end();
+  })
+})


### PR DESCRIPTION
Adds two new flags to tap to assist with debugging your node Tap tests:

--debug: Pass the '--debug' flag to node for debugging
--debug-brk: Pass the '--debug-brk' flag to node for debugging

e.g.
$ tap --debug-brk test/foo.js
debugger listening on port 5858

You can then fire up node-inspector and debug like a boss.
