### PR TITLE
fixes issue #70 - wrong args passed to path.resolve

### DIFF
--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -116,7 +116,9 @@ Runner.prototype.runDir = function (dir, cb) {
     files = files.filter(function(f) {
       return !f.match(/^\./)
     })
-    files = files.map(path.resolve.bind(path, dir))
+    files = files.map(function(dir,file){
+      return this.resolve(dir,file)
+    }.bind(path,dir))
 
     self.runFiles(files, path.resolve(dir), cb)
   })


### PR DESCRIPTION
In node 0.10 path.resolve only accepts string parameters but {array}.map passes the array index and the array itself as additional parameters.
I added a function to make sure path.resolve only gets string parameters.

fixes: https://github.com/isaacs/node-tap/issues/70
