### PR TITLE
tests: segv actually segfaults

### DIFF
--- a/test/segv.js
+++ b/test/segv.js
@@ -38,7 +38,7 @@ test('segv', function (t) {
           'name': ' ././segv',
           'exit': null,
           'timedOut': true,
-          'signal': 'SIGBUS',
+          'signal': 'SIGSEGV',
           'command': '"./segv"' }
       , 'tests 1'
       , 'fail  1' ]


### PR DESCRIPTION
The 'segv' test is written to expect SIGBUS, even though it seems to actually segfault as its name would suggest.

This patch makes it expect SIGSEGV.
