### PR TITLE
Tap hangs with Node 0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "A Test-Anything-Protocol library",
   "bin": "bin/tap.js",
   "main": "lib/main.js",
+  "engines": {
+    "node": ">=0.8"
+  },
   "dependencies": {
     "inherits": "*",
     "yamlish": "*",


### PR DESCRIPTION
With Node v0.6.21, tap hangs for 30 seconds exactly and then exits with exit code `0` without any output:

```
node-tap $ bin/tap.js test/*.js
node-tap $ echo $?
0
```

Node 0.6 ships with Ubuntu 13.04 (if you don't add Chris Lea's PPA). Is Node 0.6 still worth supporting, or has everyone moved on by now?
