### PR TITLE
Add cmd line args to enable harmony features and enforce strict mode

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -16,6 +16,8 @@ var argv = process.argv.slice(2)
     , tap: Boolean
     , timeout: Number
     , gc: Boolean
+    , strict: Boolean
+    , harmony: Boolean
     }
 
   , shorthands =
@@ -44,6 +46,8 @@ var argv = process.argv.slice(2)
     , diag: process.env.TAP_DIAG
     , timeout: +process.env.TAP_TIMEOUT || 30
     , gc: false
+    , strict: false
+    , harmony: false
     , version: false
     , help: false }
 
@@ -69,6 +73,8 @@ Options:
     --diag      Print diagnostic output for passed tests, as well as failed.
                 (Implies --tap)
     --gc        Expose the garbage collector to tests.
+    --strict    Enforce strict mode when running tests.
+    --harmony   Enable harmony features for tests.
     --timeout   Maximum time to wait for a subtest, in seconds. Default: 30
     --version   Print the version of node tap.
     --help      Print this help.

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -166,6 +166,12 @@ function runFiles(self, files, dir, cb) {
           if (self.options.gc) {
             args.push("--expose-gc")
           }
+          if (self.options.strict) {
+            args.push("--use-strict")
+          }
+          if (self.options.harmony) {
+            args.push("--harmony")
+          }
           args.push(fileName)
         } else if (path.extname(f) === ".coffee") {
           cmd = "coffee"


### PR DESCRIPTION
Just like support for --expose-gc has been added quite a while ago it would be great to support --use-strict and --harmony as well. ES6 finalization is getting closer and V8 recently implemented generator support that will be available in node 0.11.2 (well, with --harmony).

While working on a small library making use of generators I figured that it would be great to simply be able to use 'npm test' locally and also have tests run in strict mode with harmony features on Travis. Travis said they're upgrading their machines to node 0.11.2 soon.
