### PR TITLE
Add `fulfill` event to listen for when the `plan` count is met.

### DIFF
--- a/lib/tap-test.js
+++ b/lib/tap-test.js
@@ -62,6 +62,8 @@ Test.prototype.result = function (res) {
   this._testCount ++
   this.emit("result", res)
   if (this._plan === this._testCount) {
+    // plan has been met
+    this.emit("fulfill")
     process.nextTick(this._endNice.bind(this))
   }
 }


### PR DESCRIPTION
I want to test several actions (say, 5 of them) against a single http server, but I don't want to nest them and I don't really need complex async semaphore. So I set `t.plan(5)` and then send off each of my requests, each of which have an async callback doing something like `t.equal("Something", res.body)`. I want to catch when those are all done, so that I can run `server.close()` and return. This event, `fulfill`, is triggered kind of in between the last `result` event and the `end` event (which doesn't occur until the child process ends).
