### PR TITLE
fix; command field in tap output not valid

### DIFF
--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -296,7 +296,7 @@ function runFiles(self, files, dir, cb) {
 
           // tc.results.ok = tc.results.ok && ok
           tc.results.add(res)
-          res.command = [cmd].concat(args).map(JSON.stringify).join(" ")
+          res.command = '"'+[cmd].concat(args).join(" ")+'"'
           self.emit("result", res)
           self.emit("file", f, res, tc.results)
           self.write(res)

--- a/test/valid-command.js
+++ b/test/valid-command.js
@@ -1,0 +1,29 @@
+var test = require('../').test
+var Runner = require('../lib/tap-runner.js')
+var TC = require('../lib/tap-consumer.js')
+
+test('valid command', function (t) {
+  var r = new Runner({argv:{remain:['./end-exception/t.js']}})
+  var tc = new TC()
+  var expect =
+      [ 'TAP version 13'
+      , 't.js'
+      , { 'id': 1,
+          'ok': false,
+          'name': ' ./end-exception/t.js',
+          'exit': null,
+          'timedOut': true,
+          'signal': 'SIGTERM',
+          'command': '"node t.js"' }
+      , 'tests 1'
+      , 'fail  1' ]
+  r.pipe(tc)
+  tc.on('data', function (d) {
+    var e = expect.shift()
+    t.same(d, e)
+  })
+  tc.on('end', function () {
+    t.equal(expect.length, 0)
+    t.end()
+  })
+})


### PR DESCRIPTION
Currently this fails:

```
not ok 1 test/settings/settings-test.js
  ---
    exit:     143
    timedOut: true
    command:  "node" "settings-test.js"
  ...
```

Because it cannot parse the "command" value, relevant yaml parsing error is:

> expected &lt;block end&gt;, but found Scalar

This fix changes the command value to be one quoted string instead which is
valid:

```
not ok 1 test/settings/settings-test.js
  ---
    exit:     143
    timedOut: true
    command:  "node settings-test.js"
  ...
```

Tests were ran against [InstantTap](http://instanttap.appspot.com/)
