### PR TITLE
lib: don't assume 'node' is on the path

### DIFF
--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -174,7 +174,7 @@ function runFiles(self, files, dir, cb) {
         var cmd = f, args = [], env = {}
 
         if (path.extname(f) === ".js") {
-          cmd = "node"
+          cmd = process.execPath
           if (self.options.gc) {
             args.push("--expose-gc")
           }


### PR DESCRIPTION
Use process.execPath to start the test runner.  Assuming there is a
node binary on the path somewhere will break when there isn't one or
when it's the wrong version.
