### PR TITLE
Adds support for --exec (-e), specifying executable runner

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -20,6 +20,7 @@ var argv = process.argv.slice(2)
     , "debug-brk": Boolean
     , strict: Boolean
     , harmony: Boolean
+    , exec: String
     }
 
   , shorthands =
@@ -38,6 +39,7 @@ var argv = process.argv.slice(2)
     , v: ["--version"]
     , "?": ["--help"]
     , h: ["--help"]
+    , e: ["--exec"]
     }
 
   , defaults =
@@ -53,7 +55,8 @@ var argv = process.argv.slice(2)
     , strict: false
     , harmony: false
     , version: false
-    , help: false }
+    , help: false
+    , exec: null }
 
   , options = nopt(knownOpts, shorthands)
 

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -217,7 +217,9 @@ function runFiles(self, files, dir, cb) {
         if (self.options.exec) {
           var argvs = shellQuote.parse(self.options.exec), cmdy = argvs.shift()
           cmd = cmdy.match(/^[\/.\\]/) ? fs.realpathSync(cmdy) : cmdy
-          args = [].concat(argvs, args)
+          var pos = argvs.indexOf('{}') > -1 ? argvs.indexOf('{}') : argvs.length;
+          argvs.splice.apply(argvs, [pos, 1].concat(args));
+          args = argvs;
         }
 
         if (st.isDirectory()) {

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -10,6 +10,7 @@ var fs = require("fs")
   , util = require("util")
   , CovHtml = require("./tap-cov-html.js")
   , glob = require("glob")
+  , shellQuote = require('shell-quote')
 
   // XXX Clean up the coverage options
   , doCoverage = process.env.TAP_COV
@@ -214,7 +215,9 @@ function runFiles(self, files, dir, cb) {
         }
 
         if (self.options.exec) {
-          cmd = self.options.exec.match(/^[\/.\\]/) ? fs.realpathSync(self.options.exec) : self.options.exec
+          var argvs = shellQuote.parse(self.options.exec), cmdy = argvs.shift()
+          cmd = cmdy.match(/^[\/.\\]/) ? fs.realpathSync(cmdy) : cmdy
+          args = [].concat(argvs, args)
         }
 
         if (st.isDirectory()) {

--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -196,6 +196,8 @@ function runFiles(self, files, dir, cb) {
         } else if (path.extname(f) === ".coffee") {
           cmd = "coffee"
           args.push(fileName)
+        } else if (self.options.exec) {
+          args.push(fileName);
         } else {
           // Check if file is executable
           if ((st.mode & 0100) && process.getuid) {
@@ -209,6 +211,10 @@ function runFiles(self, files, dir, cb) {
           } else if ((st.mode & 0001) == 0) {
             return cb()
           }
+        }
+
+        if (self.options.exec) {
+          cmd = self.options.exec.match(/^[\/.\\]/) ? fs.realpathSync(self.options.exec) : self.options.exec
         }
 
         if (st.isDirectory()) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "difflet": "~0.2.0",
     "deep-equal": "~0.0.0",
     "buffer-equal": "~0.0.0",
-    "glob": "~3.2.1"
+    "glob": "~3.2.1",
+    "shell-quote": "~1.4.1"
   },
   "bundledDependencies": [
     "inherits",


### PR DESCRIPTION
Adds an -e flag, forcibly setting the executed command (regardless of the extension of the file, .js, .coffee, or nothing). This allows for example running an alternative JavaScript interpreter, as well as other commands.
