### PR TITLE
Make SKIP and TODO more verbose

### DIFF
--- a/lib/tap-producer.js
+++ b/lib/tap-producer.js
@@ -111,8 +111,8 @@ function encodeResult (res, count, diag) {
   output += ( !res.ok ? "not " : "") + "ok " + count
             + ( !res.name ? ""
               : " " + res.name.replace(/[\r\n]/g, " ") )
-            + ( res.skip ? " # SKIP"
-              : res.todo ? " # TODO"
+            + ( res.skip ? " # SKIP " + res.explanation
+              : res.todo ? " # TODO " + res.explanation
               : "" )
             + "\n"
 

--- a/test/fixtures/todo-skip-descriptions.js
+++ b/test/fixtures/todo-skip-descriptions.js
@@ -1,0 +1,2 @@
+console.log('ok # SKIP skip it, skip it good')
+console.log('ok # TODO something with this test')

--- a/test/test-descriptions.js
+++ b/test/test-descriptions.js
@@ -1,0 +1,25 @@
+var execFile = require('child_process').execFile
+var node = process.execPath
+var bin = require.resolve('../bin/tap.js')
+var test = require('../').test
+var path = require('path')
+var fixtures = path.resolve(__dirname, 'fixtures')
+
+test('captures test descriptions', function (t) {
+  t.plan(6)
+
+  var file = path.resolve(fixtures, 'todo-skip-descriptions.js')
+
+  execFile(node, [bin, file], function (err, stdout, stderr) {
+    t.ifError(err, 'exit cleanly')
+    t.assert(/skip it good/.test(stdout), 'captures SKIP description')
+    t.assert(/something/.test(stdout), 'captures TODO description')
+  })
+
+  execFile(node, [file], function (err, stdout, stderr) {
+    t.ifError(err, 'exit cleanly')
+    t.assert(/skip it good/.test(stdout), 'captures SKIP description')
+    t.assert(/something/.test(stdout), 'captures TODO description')
+  })
+
+})


### PR DESCRIPTION
Makes TAP reports more useful by allowing TODO and SKIP items to be annotated.

Also includes a small tweak to make the tests pass.
