### PR TITLE
runner: Support test/test-* including non-js files

### DIFF
--- a/lib/tap-runner.js
+++ b/lib/tap-runner.js
@@ -209,6 +209,7 @@ function runFiles(self, files, dir, cb) {
           } else if ((st.mode & 0001) == 0) {
             return cb()
           }
+          cmd = path.resolve(cmd)
         }
 
         if (st.isDirectory()) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": "git://github.com/isaacs/node-tap.git",
   "scripts": {
-    "test": "bin/tap.js test/*.js"
+    "test": "bin/tap.js test/*.*"
   },
   "devDependencies": {}
 }

--- a/test/not-executed.sh
+++ b/test/not-executed.sh
@@ -2,3 +2,4 @@
 
 echo "1..1"
 echo "not ok 1 File without executable bit should not be run"
+exit 1

--- a/test/segv.js
+++ b/test/segv.js
@@ -3,6 +3,7 @@ var Runner = require('../lib/tap-runner.js')
 var TC = require('../lib/tap-consumer.js')
 
 var fs = require('fs')
+var path = require('path')
 var spawn = require('child_process').spawn
 var segv =
     'int main (void) {\n' +
@@ -39,7 +40,7 @@ test('segv', function (t) {
           'exit': null,
           'timedOut': true,
           'signal': process.platform === 'linux' ? 'SIGSEGV' : 'SIGTERM',
-          'command': '"./segv"' }
+          'command': '"' + path.resolve('./segv') + '"' }
       , 'tests 1'
       , 'fail  1' ]
   r.pipe(tc)


### PR DESCRIPTION
When falling back on the "is it executable" test for files that don't
end in .js or .coffee, files that are determined to be executable as
tests should be referenced by a more complete path because $CWD is
highly unlikely to be included in $PATH.

The end result is `tap tests/test-*` works when the tests are a mix of JS and shell scripts.
