### PR TITLE
Allowed nested async tests when plan announced

### DIFF
--- a/lib/tap-harness.js
+++ b/lib/tap-harness.js
@@ -24,7 +24,7 @@ function Harness (Test) {
   this._Test = Test
   this._plan = null
   this._children = []
-  this._started = false
+  this._processing = false
 
   this._testCount = 0
   this._planSum = 0
@@ -40,7 +40,7 @@ function Harness (Test) {
 
   var p = this.process.bind(this)
   this.process = function () {
-    this._started = true
+    this._processing = true
     process.nextTick(p)
   }
 
@@ -87,13 +87,15 @@ Harness.prototype.process = function () {
     current.emit("ready")
     //console.error("emitted ready")
     //console.error("_plan", this._plan, this.constructor.name)
-  } else {
+  } else if (!this._plan || (this._plan && this._plan === this._testCount)) {
     //console.error("Harness process: no more left.  ending")
     if (this._endNice) {
       this._endNice()
     } else {
       this.end()
     }
+  } else {
+    this._processing = false;
   }
 }
 
@@ -214,7 +216,7 @@ Harness.prototype.bailout = function (message) {
 Harness.prototype.add = function (child) {
   //console.error("adding child")
   this._children.push(child)
-  if (!this._started) this.process()
+  if (!this._processing) this.process()
 }
 
 // the tearDown function is *always* guaranteed to happen.

--- a/test/nested-async.js
+++ b/test/nested-async.js
@@ -1,0 +1,36 @@
+var test = require("../").test
+
+test('Harness async test support', function(t) {
+  t.plan(3);
+
+  t.ok(true, 'sync child A');
+
+  t.test('sync child B', function(tt) {
+    tt.plan(2);
+
+    setTimeout(function(){
+      tt.test('async grandchild A', function(ttt) {
+        ttt.plan(1);
+        ttt.ok(true);
+      });
+    }, 50);
+
+    setTimeout(function() {
+      tt.test('async grandchild B', function(ttt) {
+        ttt.plan(1);
+        ttt.ok(true);
+      });
+    }, 100);
+  });
+
+  setTimeout(function() {
+    t.test('async child', function(tt) {
+      tt.plan(2);
+      tt.ok(true, 'sync grandchild in async child A');
+      tt.test('sync grandchild in async child B', function(ttt) {
+        ttt.plan(1);
+        ttt.ok(true);
+      });
+    });
+  }, 200);
+});

--- a/test/nested-test.js
+++ b/test/nested-test.js
@@ -1,6 +1,5 @@
 var tap = require("../"),
-    test = tap.test,
-    util = require('util');
+    test = tap.test;
 
 test("parent", function (t) {
   // TODO: Make grandchildren tests count?


### PR DESCRIPTION
This patch allows you to asynchronously define nested test harnesses if you first announce a plan count. e.g. If I say that 3 assertions are expected and one of the assertions is nested test set, that nested test set can be declared asynchronously, so long as it is defined and finishes before the timeout. 

Fixes #102
