### PR TITLE
Fixed tests in 0.12 / iojs

### DIFF
--- a/test/debug-test.js
+++ b/test/debug-test.js
@@ -9,8 +9,9 @@ tap.test("debug test", function (t) {
   console.error("t.plan="+t._plan)
 
   cp.exec("../bin/tap.js --debug meta-test.js", function (err, stdo, stde) {
-    console.error(util.inspect(stde)) 
-    t.notEqual(stde.indexOf("debugger listening on port"), -1, "Should output debugger message")
+    console.error(util.inspect(stde))
+    // node 0.10 print "debugger", 0.12 and iojs are printing "Debugger"
+    t.notEqual(stde.indexOf("ebugger listening on port"), -1, "Should output debugger message")
     t.end();
   })
 })


### PR DESCRIPTION
0.12 and iojs are printing “Debugger” instead of “debugger”

Fixes https://github.com/isaacs/node-tap/issues/108
