### PR TITLE
Don't fail suite if a test skips

### DIFF
--- a/lib/tap-results.js
+++ b/lib/tap-results.js
@@ -62,7 +62,7 @@ Results.prototype.add = function (r, addToList) {
       // console.error("Bailing out in result")
       this.bailedOut = true
     }
-    this.ok = !!(this.ok && r.ok)
+    this.ok = !!(this.ok && (r.ok || r.skip))
   }
 
   if (addToList === false) return

--- a/test/test-skip.js
+++ b/test/test-skip.js
@@ -1,0 +1,5 @@
+var tap = require('../');
+
+tap.test('does not count as failure', { skip: true }, function(t) {
+  t.end();
+})


### PR DESCRIPTION
Skipped tests aren't really pass or fail, so they shouldn't cause the suite to fail.

Resolves #110 
