### PR TITLE
Update timeout signal test for node > 0.10

### DIFF
--- a/test/valid-command.js
+++ b/test/valid-command.js
@@ -14,7 +14,7 @@ test('valid command', function (t) {
     'command': '"' + node + ' t.js"',
     exit: null
   }
-  if (process.platform === 'linux') {
+  if (process.platform === 'linux' && process.version < 'v0.11.0') {
     expectObj.exit = 143
   } else {
     expectObj.signal = 'SIGTERM'


### PR DESCRIPTION
Looks like newer versions of Node cleaned up this platform difference.
