### PR TITLE
Fix skipped summary

### DIFF
--- a/bin/tap.js
+++ b/bin/tap.js
@@ -114,7 +114,7 @@ if (options.tap || options.diag) {
     console.log("%s %s %s", s, dots, n)
     if (details.ok) {
       if (details.skip) {
-        console.log("  skipped: %s", details.skipTotal)
+        console.log("  skipped: %s", details.skip)
       }
     } else {
       // console.error(details)

--- a/bin/tap.js
+++ b/bin/tap.js
@@ -116,6 +116,9 @@ if (options.tap || options.diag) {
       if (details.skip) {
         console.log("  skipped: %s", details.skip)
       }
+      if (details.todo) {
+        console.log("  todo: %s", details.todo)
+      }
     } else {
       // console.error(details)
       console.log("    Command: %s", results.command)

--- a/test/test-descriptions.js
+++ b/test/test-descriptions.js
@@ -6,7 +6,7 @@ var path = require('path')
 var fixtures = path.resolve(__dirname, 'fixtures')
 
 test('captures test descriptions', function (t) {
-  t.plan(10)
+  t.plan(13)
 
   var file = path.resolve(fixtures, 'todo-skip-descriptions.js')
 
@@ -14,18 +14,21 @@ test('captures test descriptions', function (t) {
     t.ifError(err, 'exit cleanly')
     t.assert(/skip it good/.test(stdout), 'captures SKIP description')
     t.assert(!/skipped: 1/.test(stdout), 'skip summary is not in TAP output')
+    t.assert(!/todo: 1/.test(stdout), 'todo summary is not in TAP output')
     t.assert(/something/.test(stdout), 'captures TODO description')
   })
 
   execFile(node, [bin, '--no-tap', '--no-diag', file], function (err, stdout, stderr) {
     t.ifError(err, 'exit cleanly')
     t.assert(/ +skipped: 1/.test(stdout), 'summarizes skipped count')
+    t.assert(/ +todo: 1/.test(stdout), 'summarizes todo count')
   })
 
   execFile(node, [file], function (err, stdout, stderr) {
     t.ifError(err, 'exit cleanly')
     t.assert(/skip it good/.test(stdout), 'captures SKIP description')
     t.assert(!/skipped: 1/.test(stdout), 'skip summary is not from file')
+    t.assert(!/todo: 1/.test(stdout), 'todo summary is not from file')
     t.assert(/something/.test(stdout), 'captures TODO description')
   })
 

--- a/test/test-descriptions.js
+++ b/test/test-descriptions.js
@@ -6,19 +6,26 @@ var path = require('path')
 var fixtures = path.resolve(__dirname, 'fixtures')
 
 test('captures test descriptions', function (t) {
-  t.plan(6)
+  t.plan(10)
 
   var file = path.resolve(fixtures, 'todo-skip-descriptions.js')
 
   execFile(node, [bin, file], function (err, stdout, stderr) {
     t.ifError(err, 'exit cleanly')
     t.assert(/skip it good/.test(stdout), 'captures SKIP description')
+    t.assert(!/skipped: 1/.test(stdout), 'skip summary is not in TAP output')
     t.assert(/something/.test(stdout), 'captures TODO description')
+  })
+
+  execFile(node, [bin, '--no-tap', '--no-diag', file], function (err, stdout, stderr) {
+    t.ifError(err, 'exit cleanly')
+    t.assert(/ +skipped: 1/.test(stdout), 'summarizes skipped count')
   })
 
   execFile(node, [file], function (err, stdout, stderr) {
     t.ifError(err, 'exit cleanly')
     t.assert(/skip it good/.test(stdout), 'captures SKIP description')
+    t.assert(!/skipped: 1/.test(stdout), 'skip summary is not from file')
     t.assert(/something/.test(stdout), 'captures TODO description')
   })
 


### PR DESCRIPTION
Fixes `skipped: undefined` in default summary mode and adds a `todo: N` for todo's:

Before:

```
ok test/test-api.js ..................................... 5/7
  skipped: undefined
ok test/test-keystore.js ................................ 1/2
  skipped: undefined
ok test/test-negative.js ................................ 3/3
ok test/test-perpetual.js ............................... 3/3
total ................................................. 12/15

ok
```

After:

```
ok test/test-api.js ..................................... 5/7
  skipped: 1
  todo: 1
ok test/test-keystore.js ................................ 1/2
  skipped: 1
ok test/test-negative.js ................................ 3/3
ok test/test-perpetual.js ............................... 3/3
total ................................................. 12/15

ok
```
