### PR TITLE
omit tests and examples from published tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+test-disabled
+coverage-example


### PR DESCRIPTION
The tests include many examples of working and broken TAP reports that
were not present in previous versions, which is unfriendly to CI jobs
that scan aggressively for *_/_.tap test reports.

@isaacs this is assuming the empty `.npmignore` that was already in the repo was there intentionally.
