### PR TITLE
mocha: handle error arg in done(err)

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -19,8 +19,9 @@ function it (name, fn) {
 
   if (fn && fn.length)
     c.test(name, { at: at }, function (tt) {
-      fn(function () {
-        tt.end()
+      fn(function (err) {
+        if (err) tt.threw(err)
+        else tt.end()
       })
     })
   else
@@ -34,8 +35,9 @@ function describe (name, fn) {
     c.test(name, { at: at })
   else if (fn.length)
     c.test(name, { at: at }, function (tt) {
-      fn(function () {
-        tt.end()
+      fn(function (err) {
+        if (err) tt.threw(err)
+        else tt.end()
       })
     })
   else

--- a/test/test/mochalike.js
+++ b/test/test/mochalike.js
@@ -59,3 +59,11 @@ describe('failing indented things', function () {
     ok(!{}, 'objectify the truthiness')
   })
 })
+
+describe('a test passing an error to done() callback', function() {
+  it('is marked as failed', function(done) {
+    process.nextTick(function() {
+      done(new Error('error arg'))
+    });
+  });
+});

--- a/test/test/mochalike.tap
+++ b/test/test/mochalike.tap
@@ -75,8 +75,28 @@ not ok 5 - failing indented things ___/# time=[0-9.]+(ms)?/~~~
   {"at":{"file":"test/test/mochalike.js","line":49,"column":1},"results":{"plan":{"start":1,"end":2},"count":2,"pass":0,"ok":false,"fail":2},"source":"describe('failing indented things', function () {\n"}
   ...
 
-1..5
-# failed 1 of 5 tests
+    # Subtest: a test passing an error to done() callback
+        # Subtest: is marked as failed
+        not ok 1 - Error: error arg
+          ---
+          {"at":{"file":"test/test/mochalike.js","line":66,"column":12},"test":"is marked as failed","message":"Error: error arg","source":"done(new Error('error arg'));\n"}
+          ...
+        1..1
+        # failed 1 of 1 tests
+    not ok 1 - is marked as failed ___/# time=[0-9.]+(ms)?/~~~
+      ---
+      {"at":{"file":"test/test/mochalike.js","line":64,"column":3},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"it('is marked as failed', function(done) {\n"}
+      ...
+
+    1..1
+    # failed 1 of 1 tests
+not ok 6 - a test passing an error to done() callback ___/# time=[0-9.]+(ms)?/~~~
+  ---
+  {"at":{"file":"test/test/mochalike.js","line":63,"column":1},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"describe('a test passing an error to done() callback', function() {\n"}
+  ...
+
+1..6
+# failed 2 of 6 tests
 # todo: 2
 ___/# time=[0-9.]+(ms)?/~~~
 


### PR DESCRIPTION
Allow individual tests to fail the test by passing an error to the `done` callback provided to `it` and `describe` methods.

An example of a typical Mocha tests that uses this feature:

``` js
it('reads file contents', function(done) {
  fs.readFile('foo.txt', function(err, text) {
    if (err) return done(err); // <-- THIS IS THE IMPORTANT PART
    expect(text).to.contain('foo');
    done();
  });
});
```

R=@isaacs ?
