### PR TITLE
tap: suppress TAP header in subtests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -407,6 +407,8 @@ function childStream (self, child) {
         return
       if (line.match(/^Bail out!/))
         bailedOut = true
+      if (line.match(/^\s*TAP version \d+$/))
+        return
       if (line.trim())
         line = '    ' + line
       self.push(line + '\n')

--- a/test/test/bail-fail-spawn-bail.tap
+++ b/test/test/bail-fail-spawn-bail.tap
@@ -1,7 +1,6 @@
 TAP version 13
     # Subtest: bail fail
         # Subtest: ./test/test/nesting.js
-        TAP version 13
             # Subtest: nesting
             1..2
                 # Subtest: first

--- a/test/test/bail-fail-spawn.tap
+++ b/test/test/bail-fail-spawn.tap
@@ -1,7 +1,6 @@
 TAP version 13
     # Subtest: bail fail
         # Subtest: ./test/test/nesting.js
-        TAP version 13
             # Subtest: nesting
             1..2
                 # Subtest: first

--- a/test/test/mochalike.tap
+++ b/test/test/mochalike.tap
@@ -79,7 +79,7 @@ not ok 5 - failing indented things ___/# time=[0-9.]+(ms)?/~~~
         # Subtest: is marked as failed
         not ok 1 - Error: error arg
           ---
-          {"at":{"file":"test/test/mochalike.js","line":66,"column":12},"test":"is marked as failed","message":"Error: error arg","source":"done(new Error('error arg'));\n"}
+          {"at":{"file":"test/test/mochalike.js","line":66,"column":12},"test":"is marked as failed","message":"Error: error arg","source":"done(new Error('error arg'))\n"}
           ...
         1..1
         # failed 1 of 1 tests

--- a/test/test/spawn-bail.tap
+++ b/test/test/spawn-bail.tap
@@ -1,6 +1,5 @@
 TAP version 13
     # Subtest: ___/.*/~~~spawn.js child
-    TAP version 13
         # Subtest: nesting
         1..2
             # Subtest: first
@@ -16,7 +15,8 @@ TAP version 13
               ---
               {"found":1,"wanted":"1","compare":"===","at":{"file":"test/test/spawn.js","line":22,"column":10,"function":"foo"},"source":"tt.equal(1, '1', 'nested failure')\n"}
               ...
-
+            Bail out! # nested failure
+        Bail out! # nested failure
     Bail out! # nested failure
 Bail out! # nested failure
 

--- a/test/test/spawn-stderr-bail.tap
+++ b/test/test/spawn-stderr-bail.tap
@@ -1,7 +1,6 @@
 TAP version 13
     # Subtest: ___/.*/~~~spawn-stderr.js child
     stdout
-    TAP version 13
     ok 1 - this is ok
     1..1
     ___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/spawn-stderr.tap
+++ b/test/test/spawn-stderr.tap
@@ -1,7 +1,6 @@
 TAP version 13
     # Subtest: ___/.*/~~~spawn-stderr.js child
     stdout
-    TAP version 13
     ok 1 - this is ok
     1..1
     ___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/spawn.tap
+++ b/test/test/spawn.tap
@@ -1,6 +1,5 @@
 TAP version 13
     # Subtest: ___/.*/~~~spawn.js child
-    TAP version 13
         # Subtest: nesting
         1..2
             # Subtest: first


### PR DESCRIPTION
There appears to be no official standard for subtests, but the tap4j
that the Jenkins TAP plugin uses seems to expect only one header and
barfs if the subtests include their own headers.

See http://instanttap.appspot.com/
