### PR TITLE
Handle circular references in errors. Fixes #156

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -873,7 +873,7 @@ Test.prototype.printResult = function printResult (ok, message, extra) {
   this._maybeAutoend()
 }
 
-function cleanYamlObj(object, isRoot) {
+function cleanYamlObj(object, isRoot, seen) {
   if (object === undefined)
     return null
 
@@ -900,7 +900,11 @@ function cleanYamlObj(object, isRoot) {
         return set
       }
 
-      set[k] = cleanYamlObj(object[k], false)
+      if (seen.indexOf(object[k]) !== -1) {
+        set[k] = '[Circular]';
+      } else {
+        set[k] = cleanYamlObj(object[k], false, seen.concat([object]))
+      }
       return set
     }, set)
     if (stack)
@@ -930,7 +934,7 @@ Test.prototype.writeDiags = function (extra) {
   }
 
   // some objects are not suitable for yaml.
-  var obj = cleanYamlObj(extra, true)
+  var obj = cleanYamlObj(extra, true, [])
 
   if (obj && typeof obj === 'object' && Object.keys(obj).length) {
     var y = yaml.safeDump(obj).split('\n').map(function (l) {

--- a/test/asserts.js
+++ b/test/asserts.js
@@ -30,6 +30,11 @@ test('error tests for errorness', function (t) {
   tt.on('data', function (chunk) { c += chunk })
 
   t.notOk(tt.error(er), 'fails when presented error')
+
+  var circular = {};
+  circular.circular = circular;
+  t.notOk(tt.error(circular), 'fails when presented circular object')
+
   falsies.forEach(function (falsey) {
     t.error(falsey, 'passes with ' + util.inspect(falsey))
   })


### PR DESCRIPTION
This modifies the cleanYamlObj method to handle circular references
in data, replacing the reference with [Circular] instead of
throwing an error.
