### PR TITLE
Fail on unfinished tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -137,16 +137,18 @@ Test.prototype.setTimeout = function (n) {
 Test.prototype._onTimeout = function () {
   var s = this
   while (s._currentChild && (s._currentChild instanceof Test)) {
+    s._queue = []
+    s.end()
     s = s._currentChild
   }
 
   // anything that was pending will have to wait.
-  s._queue = []
   s.fail('timeout!', {
     expired: this._name,
     timeout: this._timeout,
     at: this._calledAt
   })
+  s.end()
 
   this.endAll()
 }
@@ -157,15 +159,55 @@ function domainError (er) {
   this.owner.threw(er)
 }
 
-Test.prototype.endAll = function () {
-  var child = this._currentChild
-  if (child) {
-    child._queue = []
-    if (!child._ended && !child._plan && child.fail) {
-      child.fail('test left unfinished: no end(), no plan()', {
+// Called when endAll() is fired and there's stuff in the queue
+Test.prototype._queueFail = function () {
+  var queue = this._queue
+  this._queue = []
+  var len = queue.length
+  queue.forEach(function (q) {
+    var what = q[0]
+    var msg = what + ' left in queue'
+    var extra = { at: null }
+    if (what === 'test') {
+      extra = q[2]
+      if (q[1])
+        extra.name = q[1]
+      this.fail('child test left in queue', extra)
+    } else if (what === 'printResult') {
+      if (q[2] === 'test left unfinished: no end(), no plan()')
+        return
+      var msg = (q[1] ? 'ok' : 'not ok') + ' - ' + q[2].trim()
+      q[3].at = q[3].at || null
+      this.fail('test point left in queue: ' + (msg || '(no message)') , q[3])
+    } else if (what === 'spawn') {
+      extra = q[5]
+      extra.command = q[1]
+      extra.args = q[2]
+      extra.options = q[3],
+      extra.name = q[4]
+      this.fail('spawn left in queue', extra)
+    } else if (what === 'end') {
+      return
+    } else {
+      this.fail('left in queue: ' + what, {
         at: this._calledAt
       })
     }
+  }, this)
+}
+
+Test.prototype.endAll = function () {
+  var child = this._currentChild
+
+  if (this._queue && this._queue.length)
+    this._queueFail()
+
+  if (child) {
+    child._queue = []
+    if (!child._ended && -1 === child._plan && child.fail)
+      child.fail('test left unfinished: no end(), no plan()', {
+        at: null
+      })
     if (child.end)
       child.end()
     if (child.endAll)
@@ -810,6 +852,9 @@ Test.prototype.printResult = function printResult (ok, message, extra) {
     clearTimeout(this._autoendTimer)
 
   if (this._currentChild) {
+    // Might get abandoned in queue
+    if (!hasOwn(extra, 'at'))
+      extra.at = stack.at(fn)
     this._queue.push(['printResult', ok, message, extra])
     return
   }

--- a/test/test/spawn-stderr.js
+++ b/test/test/spawn-stderr.js
@@ -1,4 +1,4 @@
-var tap = require('../../lib/root.js')
+var tap = require('../..')
 
 if (!process.argv[2]) {
   tap.spawn(process.execPath, [ __filename, 'child' ])

--- a/test/test/unfinished-bail.tap
+++ b/test/test/unfinished-bail.tap
@@ -1,17 +1,7 @@
 TAP version 13
-    # Subtest: parent
-        # Subtest: child 1
-            # Subtest: grandchild 1
-            ok 1 - 1
-            1..1
-        ok 1 - grandchild 1 ___/# time=[0-9.]+(ms)?/~~~
-
-        1..1
-    ok 1 - child 1 ___/# time=[0-9.]+(ms)?/~~~
-
-    1..1
-ok 1 - parent ___/# time=[0-9.]+(ms)?/~~~
-
-1..1
-___/# time=[0-9.]+(ms)?/~~~
+    # Subtest: t1
+        # Subtest: t11
+        not ok 1 - test left unfinished: no end(), no plan()
+        Bail out! # test left unfinished: no end(), no plan()
+Bail out! # test left unfinished: no end(), no plan()
 

--- a/test/test/unfinished.js
+++ b/test/test/unfinished.js
@@ -1,16 +1,34 @@
-var tap = require('../..')
+var tap = require('../..');
 
-tap.test('parent', function(t) {
-  t.test('child 1', function(t) {
-    t.test('grandchild 1', function(t) {
-      t.pass('1')
-      t.end()
-    })
+tap.test('t1', function(t) {
+  t.test('t11', function (t) {
+    process.on('some event that never happens', function() {
+      t.pass('ok');
+    });
   })
-  t.test('child 2', function(t) {
-    t.test('grandchild 2', function(t) {
-      t.pass('2')
-      t.end()
-    })
-  })
-})
+  t.end()
+});
+
+tap.equal(1, 1, '1 === 1')
+tap.ok('this is ok')
+tap.fail('failsome', { hoo: 'hah' })
+
+tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })
+
+tap.test(function(t) {
+  process.nextTick(function() {
+    t.end();
+  });
+});
+
+tap.test('', function(t) {
+  process.nextTick(function() {
+    t.end();
+  });
+});
+
+tap.test('t2', function(t) {
+  process.nextTick(function() {
+    t.end();
+  });
+});

--- a/test/test/unfinished.tap
+++ b/test/test/unfinished.tap
@@ -1,17 +1,50 @@
 TAP version 13
-    # Subtest: parent
-        # Subtest: child 1
-            # Subtest: grandchild 1
-            ok 1 - 1
-            1..1
-        ok 1 - grandchild 1 ___/# time=[0-9.]+(ms)?/~~~
-
+    # Subtest: t1
+        # Subtest: t11
+        not ok 1 - test left unfinished: no end(), no plan()
         1..1
-    ok 1 - child 1 ___/# time=[0-9.]+(ms)?/~~~
+        # failed 1 of 1 tests
+    not ok 1 - t11 ___/# time=[0-9.]+(ms)?/~~~
+      ---
+      {"at":{"file":"test/test/unfinished.js","line":4,"column":5},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"t.test('t11', function (t) {\n"}
+      ...
 
     1..1
-ok 1 - parent ___/# time=[0-9.]+(ms)?/~~~
+    # failed 1 of 1 tests
+not ok 1 - t1 ___/# time=[0-9.]+(ms)?/~~~
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":3,"column":5},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"tap.test('t1', function(t) {\n"}
+  ...
 
-1..1
+not ok 2 - test point left in queue: ok - 1 === 1
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":12,"column":5},"source":"tap.equal(1, 1, '1 === 1')\n"}
+  ...
+not ok 3 - test point left in queue: ok - expect truthy value
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":13,"column":5},"source":"tap.ok('this is ok')\n"}
+  ...
+not ok 4 - test point left in queue: not ok - failsome
+  ---
+  {"hoo":"hah","at":{"file":"test/test/unfinished.js","line":14,"column":5},"source":"tap.fail('failsome', { hoo: 'hah' })\n"}
+  ...
+not ok 5 - spawn left in queue
+  ---
+  {"rar":"grr","at":{"file":"test/test/unfinished.js","line":16,"column":5},"command":"node","args":["___/.*/~~~unfinished.js"],"options":{},"name":"spawny","source":"tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })\n"}
+  ...
+not ok 6 - child test left in queue
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":18,"column":5},"source":"tap.test(function(t) {\n"}
+  ...
+not ok 7 - child test left in queue
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":24,"column":5},"source":"tap.test('', function(t) {\n"}
+  ...
+not ok 8 - child test left in queue
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":30,"column":5},"name":"t2","source":"tap.test('t2', function(t) {\n"}
+  ...
+1..8
+# failed 8 of 8 tests
 ___/# time=[0-9.]+(ms)?/~~~
 


### PR DESCRIPTION
Fix #161

This is a pretty significant change.  It may introduce some annoying
test failures in some cases, but most likely, those are tests that were
silently being ignored before.

Now, when `t.endAll()` is called, if there's anything waiting in the
queue, it will be treated as a failure, and reported with extreme
prejudice.  It should be virtually impossible after this change to ever
have a test simply be ignored or have the tap stream cut off after
starting a new child test.

r? @sam-github @rmg 
