### PR TITLE
Fail on unfinished tests

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -337,6 +337,8 @@ var TMR = require('tap-mocha-reporter')
 if (files.length === 1 && files[0] === '-') {
   // if we didn't specify any files, then just passthrough
   // to the reporter, so we don't get '/dev/stdin' in the suite list.
+  // We have to pause() before piping to switch streams2 into old-mode
+  process.stdin.pause()
   reporter = new TMR(reporter)
   process.stdin.pipe(reporter)
   process.stdin.resume()

--- a/lib/test.js
+++ b/lib/test.js
@@ -137,16 +137,18 @@ Test.prototype.setTimeout = function (n) {
 Test.prototype._onTimeout = function () {
   var s = this
   while (s._currentChild && (s._currentChild instanceof Test)) {
+    s._queue = []
+    s.end()
     s = s._currentChild
   }
 
   // anything that was pending will have to wait.
-  s._queue = []
   s.fail('timeout!', {
     expired: this._name,
     timeout: this._timeout,
     at: this._calledAt
   })
+  s.end()
 
   this.endAll()
 }
@@ -157,15 +159,55 @@ function domainError (er) {
   this.owner.threw(er)
 }
 
-Test.prototype.endAll = function () {
-  var child = this._currentChild
-  if (child) {
-    child._queue = []
-    if (!child._ended && !child._plan && child.fail) {
-      child.fail('test left unfinished: no end(), no plan()', {
+// Called when endAll() is fired and there's stuff in the queue
+Test.prototype._queueFail = function () {
+  var queue = this._queue
+  this._queue = []
+  var len = queue.length
+  queue.forEach(function (q) {
+    var what = q[0]
+    var msg = what + ' left in queue'
+    var extra = { at: null }
+    if (what === 'test') {
+      extra = q[2]
+      if (q[1])
+        extra.name = q[1]
+      this.fail('child test left in queue', extra)
+    } else if (what === 'printResult') {
+      if (q[2] === 'test left unfinished: no end(), no plan()')
+        return
+      var msg = (q[1] ? 'ok' : 'not ok') + ' - ' + q[2].trim()
+      q[3].at = q[3].at || null
+      this.fail('test point left in queue: ' + (msg || '(no message)') , q[3])
+    } else if (what === 'spawn') {
+      extra = q[5]
+      extra.command = q[1]
+      extra.args = q[2]
+      extra.options = q[3],
+      extra.name = q[4]
+      this.fail('spawn left in queue', extra)
+    } else if (what === 'end') {
+      return
+    } else {
+      this.fail('left in queue: ' + what, {
         at: this._calledAt
       })
     }
+  }, this)
+}
+
+Test.prototype.endAll = function () {
+  var child = this._currentChild
+
+  if (this._queue && this._queue.length)
+    this._queueFail()
+
+  if (child) {
+    child._queue = []
+    if (!child._ended && -1 === child._plan && child.fail)
+      child.fail('test left unfinished: no end(), no plan()', {
+        at: null
+      })
     if (child.end)
       child.end()
     if (child.endAll)
@@ -810,6 +852,9 @@ Test.prototype.printResult = function printResult (ok, message, extra) {
     clearTimeout(this._autoendTimer)
 
   if (this._currentChild) {
+    // Might get abandoned in queue
+    if (!hasOwn(extra, 'at'))
+      extra.at = stack.at(fn)
     this._queue.push(['printResult', ok, message, extra])
     return
   }

--- a/lib/test.js
+++ b/lib/test.js
@@ -164,35 +164,43 @@ Test.prototype._queueFail = function () {
   var queue = this._queue
   this._queue = []
   var len = queue.length
+
   queue.forEach(function (q) {
     var what = q[0]
     var msg = what + ' left in queue'
-    var extra = { at: null }
-    if (what === 'test') {
+    var extra = { at: this._calledAt }
+
+    switch (what) {
+    case 'test':
       extra = q[2]
-      if (q[1])
-        extra.name = q[1]
-      this.fail('child test left in queue', extra)
-    } else if (what === 'printResult') {
-      if (q[2] === 'test left unfinished: no end(), no plan()')
+      msg = 'child test left in queue: ' + (q[1] || '(unnamed)')
+      break
+
+    case 'printResult':
+      if (q[2] === 'test unfinished: ' + (this._name || '(unnamed)'))
         return
       var msg = (q[1] ? 'ok' : 'not ok') + ' - ' + q[2].trim()
-      q[3].at = q[3].at || null
-      this.fail('test point left in queue: ' + (msg || '(no message)') , q[3])
-    } else if (what === 'spawn') {
+      msg = 'test point left in queue: ' + msg
+      extra = q[3]
+      extra.at = extra.at || null
+      break
+
+    case 'spawn':
       extra = q[5]
       extra.command = q[1]
       extra.args = q[2]
-      extra.options = q[3],
-      extra.name = q[4]
-      this.fail('spawn left in queue', extra)
-    } else if (what === 'end') {
+      extra.options = q[3]
+      msg = 'spawn left in queue: ' + (q[4] || '(unnamed)')
+      break
+
+    case 'end':
       return
-    } else {
-      this.fail('left in queue: ' + what, {
-        at: this._calledAt
-      })
     }
+
+    if (this._parent)
+      extra.test = this._name
+
+    this.fail(msg, extra)
   }, this)
 }
 
@@ -203,17 +211,25 @@ Test.prototype.endAll = function () {
     this._queueFail()
 
   if (child) {
-    child._queue = []
-    if (!child._ended && -1 === child._plan && child.fail)
-      child.fail('test left unfinished: no end(), no plan()', {
-        at: null
-      })
+    if (!child._ended && child.fail) {
+      var msg = 'test unfinished: ' + (child._name || '(unnamed)')
+      var extra = { at: child._calledAt }
+      if (child._plan !== -1) {
+        extra.plan = child._plan
+        extra.count = child._count
+      }
+      child.fail(msg, extra)
+    }
+
     if (child.end)
       child.end()
+
     if (child.endAll)
       child.endAll()
+
     if (child.kill)
       child.kill('SIGTERM')
+
     child._bailedOut = true
   }
 

--- a/test/independent-timeouts.js
+++ b/test/independent-timeouts.js
@@ -17,6 +17,7 @@ test("finishes in time too", {timeout: 100}, function(t) {
 })
 
 test('does not finish in time', function (t) {
+  t.plan(1)
   var tt = new Test()
   tt.test('timeout', { timeout: 50 }, function (ttt) {
     setTimeout(function () {

--- a/test/test/plan-too-many-bail.tap
+++ b/test/test/plan-too-many-bail.tap
@@ -6,7 +6,10 @@ TAP version 13
         # Subtest: grandchild
         1..8
         ok 1 - i am planning big things
-        not ok 2 - missing test
-        Bail out! # missing test
-Bail out! # missing test
+        not ok 2 - test unfinished: grandchild
+          ---
+          {"at":{"file":"test/test/plan-too-many.js","line":7,"column":5},"plan":8,"count":1,"source":"t.test('grandchild', function (tt) {\n"}
+          ...
+        Bail out! # test unfinished: grandchild
+Bail out! # test unfinished: grandchild
 

--- a/test/test/plan-too-many.tap
+++ b/test/test/plan-too-many.tap
@@ -6,7 +6,10 @@ TAP version 13
         # Subtest: grandchild
         1..8
         ok 1 - i am planning big things
-        not ok 2 - missing test
+        not ok 2 - test unfinished: grandchild
+          ---
+          {"at":{"file":"test/test/plan-too-many.js","line":7,"column":5},"plan":8,"count":1,"source":"t.test('grandchild', function (tt) {\n"}
+          ...
         not ok 3 - missing test
         not ok 4 - missing test
         not ok 5 - missing test

--- a/test/test/spawn-stderr.js
+++ b/test/test/spawn-stderr.js
@@ -1,4 +1,4 @@
-var tap = require('../../lib/root.js')
+var tap = require('../..')
 
 if (!process.argv[2]) {
   tap.spawn(process.execPath, [ __filename, 'child' ])

--- a/test/test/unfinished-bail.tap
+++ b/test/test/unfinished-bail.tap
@@ -1,7 +1,11 @@
 TAP version 13
     # Subtest: t1
         # Subtest: t11
-        not ok 1 - test left unfinished: no end(), no plan()
-        Bail out! # test left unfinished: no end(), no plan()
-Bail out! # test left unfinished: no end(), no plan()
+        1..1
+        not ok 1 - test unfinished: t11
+          ---
+          {"at":{"file":"test/test/unfinished.js","line":4,"column":5},"plan":1,"count":0,"source":"t.test('t11', function (t) {\n"}
+          ...
+        Bail out! # test unfinished: t11
+Bail out! # test unfinished: t11
 

--- a/test/test/unfinished-bail.tap
+++ b/test/test/unfinished-bail.tap
@@ -1,17 +1,7 @@
 TAP version 13
-    # Subtest: parent
-        # Subtest: child 1
-            # Subtest: grandchild 1
-            ok 1 - 1
-            1..1
-        ok 1 - grandchild 1 ___/# time=[0-9.]+(ms)?/~~~
-
-        1..1
-    ok 1 - child 1 ___/# time=[0-9.]+(ms)?/~~~
-
-    1..1
-ok 1 - parent ___/# time=[0-9.]+(ms)?/~~~
-
-1..1
-___/# time=[0-9.]+(ms)?/~~~
+    # Subtest: t1
+        # Subtest: t11
+        not ok 1 - test left unfinished: no end(), no plan()
+        Bail out! # test left unfinished: no end(), no plan()
+Bail out! # test left unfinished: no end(), no plan()
 

--- a/test/test/unfinished.js
+++ b/test/test/unfinished.js
@@ -2,10 +2,19 @@ var tap = require('../..');
 
 tap.test('t1', function(t) {
   t.test('t11', function (t) {
+    t.plan(1)
     process.on('some event that never happens', function() {
       t.pass('ok');
     });
   })
+
+  // Nothing beyond this point will actually be processed
+  // Everything will just get stuffed into the queue, because
+  // the child test above is unfinished.  When the process
+  // ends, because there's no pending IO, it'll emit a bunch of
+  // failures indicating that they were abandoned in the queue.
+
+  t.ok(true, 'this would be ok if it ever happened')
   t.end()
 });
 
@@ -14,21 +23,16 @@ tap.ok('this is ok')
 tap.fail('failsome', { hoo: 'hah' })
 
 tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })
+tap.spawn('node', ['--version'], {}, '', { rar: 'grr' })
 
 tap.test(function(t) {
-  process.nextTick(function() {
-    t.end();
-  });
-});
+  process.nextTick(t.end)
+})
 
 tap.test('', function(t) {
-  process.nextTick(function() {
-    t.end();
-  });
-});
+  process.nextTick(t.end)
+})
 
 tap.test('t2', function(t) {
-  process.nextTick(function() {
-    t.end();
-  });
+  process.nextTick(t.end)
 });

--- a/test/test/unfinished.js
+++ b/test/test/unfinished.js
@@ -1,16 +1,34 @@
-var tap = require('../..')
+var tap = require('../..');
 
-tap.test('parent', function(t) {
-  t.test('child 1', function(t) {
-    t.test('grandchild 1', function(t) {
-      t.pass('1')
-      t.end()
-    })
+tap.test('t1', function(t) {
+  t.test('t11', function (t) {
+    process.on('some event that never happens', function() {
+      t.pass('ok');
+    });
   })
-  t.test('child 2', function(t) {
-    t.test('grandchild 2', function(t) {
-      t.pass('2')
-      t.end()
-    })
-  })
-})
+  t.end()
+});
+
+tap.equal(1, 1, '1 === 1')
+tap.ok('this is ok')
+tap.fail('failsome', { hoo: 'hah' })
+
+tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })
+
+tap.test(function(t) {
+  process.nextTick(function() {
+    t.end();
+  });
+});
+
+tap.test('', function(t) {
+  process.nextTick(function() {
+    t.end();
+  });
+});
+
+tap.test('t2', function(t) {
+  process.nextTick(function() {
+    t.end();
+  });
+});

--- a/test/test/unfinished.tap
+++ b/test/test/unfinished.tap
@@ -1,50 +1,61 @@
 TAP version 13
     # Subtest: t1
         # Subtest: t11
-        not ok 1 - test left unfinished: no end(), no plan()
         1..1
+        not ok 1 - test unfinished: t11
+          ---
+          {"at":{"file":"test/test/unfinished.js","line":4,"column":5},"plan":1,"count":0,"source":"t.test('t11', function (t) {\n"}
+          ...
         # failed 1 of 1 tests
     not ok 1 - t11 ___/# time=[0-9.]+(ms)?/~~~
       ---
       {"at":{"file":"test/test/unfinished.js","line":4,"column":5},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"t.test('t11', function (t) {\n"}
       ...
 
-    1..1
-    # failed 1 of 1 tests
+    not ok 2 - test point left in queue: ok - this would be ok if it ever happened
+      ---
+      {"at":{"file":"test/test/unfinished.js","line":17,"column":5},"test":"t1","source":"t.ok(true, 'this would be ok if it ever happened')\n"}
+      ...
+    1..2
+    # failed 2 of 2 tests
 not ok 1 - t1 ___/# time=[0-9.]+(ms)?/~~~
   ---
-  {"at":{"file":"test/test/unfinished.js","line":3,"column":5},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"tap.test('t1', function(t) {\n"}
+  {"at":{"file":"test/test/unfinished.js","line":3,"column":5},"results":{"plan":{"start":1,"end":2},"count":2,"pass":0,"ok":false,"fail":2},"source":"tap.test('t1', function(t) {\n"}
   ...
 
 not ok 2 - test point left in queue: ok - 1 === 1
   ---
-  {"at":{"file":"test/test/unfinished.js","line":12,"column":5},"source":"tap.equal(1, 1, '1 === 1')\n"}
+  {"at":{"file":"test/test/unfinished.js","line":21,"column":5},"source":"tap.equal(1, 1, '1 === 1')\n"}
   ...
 not ok 3 - test point left in queue: ok - expect truthy value
   ---
-  {"at":{"file":"test/test/unfinished.js","line":13,"column":5},"source":"tap.ok('this is ok')\n"}
+  {"at":{"file":"test/test/unfinished.js","line":22,"column":5},"source":"tap.ok('this is ok')\n"}
   ...
 not ok 4 - test point left in queue: not ok - failsome
   ---
-  {"hoo":"hah","at":{"file":"test/test/unfinished.js","line":14,"column":5},"source":"tap.fail('failsome', { hoo: 'hah' })\n"}
+  {"hoo":"hah","at":{"file":"test/test/unfinished.js","line":23,"column":5},"source":"tap.fail('failsome', { hoo: 'hah' })\n"}
   ...
-not ok 5 - spawn left in queue
+not ok 5 - spawn left in queue: spawny
   ---
-  {"rar":"grr","at":{"file":"test/test/unfinished.js","line":16,"column":5},"command":"node","args":["___/.*/~~~unfinished.js"],"options":{},"name":"spawny","source":"tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })\n"}
+  {"rar":"grr","at":{"file":"test/test/unfinished.js","line":25,"column":5},"command":"node","args":["___/.*/~~~unfinished.js"],"options":{},"source":"tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })\n"}
   ...
-not ok 6 - child test left in queue
+not ok 6 - spawn left in queue: node --version
   ---
-  {"at":{"file":"test/test/unfinished.js","line":18,"column":5},"source":"tap.test(function(t) {\n"}
+  {"rar":"grr","at":{"file":"test/test/unfinished.js","line":26,"column":5},"command":"node","args":["--version"],"options":{},"source":"tap.spawn('node', ['--version'], {}, '', { rar: 'grr' })\n"}
   ...
-not ok 7 - child test left in queue
+not ok 7 - child test left in queue: (unnamed)
   ---
-  {"at":{"file":"test/test/unfinished.js","line":24,"column":5},"source":"tap.test('', function(t) {\n"}
+  {"at":{"file":"test/test/unfinished.js","line":28,"column":5},"source":"tap.test(function(t) {\n"}
   ...
-not ok 8 - child test left in queue
+not ok 8 - child test left in queue: (unnamed)
   ---
-  {"at":{"file":"test/test/unfinished.js","line":30,"column":5},"name":"t2","source":"tap.test('t2', function(t) {\n"}
+  {"at":{"file":"test/test/unfinished.js","line":32,"column":5},"source":"tap.test('', function(t) {\n"}
   ...
-1..8
-# failed 8 of 8 tests
+not ok 9 - child test left in queue: t2
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":36,"column":5},"source":"tap.test('t2', function(t) {\n"}
+  ...
+1..9
+# failed 9 of 9 tests
 ___/# time=[0-9.]+(ms)?/~~~
 

--- a/test/test/unfinished.tap
+++ b/test/test/unfinished.tap
@@ -1,17 +1,50 @@
 TAP version 13
-    # Subtest: parent
-        # Subtest: child 1
-            # Subtest: grandchild 1
-            ok 1 - 1
-            1..1
-        ok 1 - grandchild 1 ___/# time=[0-9.]+(ms)?/~~~
-
+    # Subtest: t1
+        # Subtest: t11
+        not ok 1 - test left unfinished: no end(), no plan()
         1..1
-    ok 1 - child 1 ___/# time=[0-9.]+(ms)?/~~~
+        # failed 1 of 1 tests
+    not ok 1 - t11 ___/# time=[0-9.]+(ms)?/~~~
+      ---
+      {"at":{"file":"test/test/unfinished.js","line":4,"column":5},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"t.test('t11', function (t) {\n"}
+      ...
 
     1..1
-ok 1 - parent ___/# time=[0-9.]+(ms)?/~~~
+    # failed 1 of 1 tests
+not ok 1 - t1 ___/# time=[0-9.]+(ms)?/~~~
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":3,"column":5},"results":{"plan":{"start":1,"end":1},"count":1,"pass":0,"ok":false,"fail":1},"source":"tap.test('t1', function(t) {\n"}
+  ...
 
-1..1
+not ok 2 - test point left in queue: ok - 1 === 1
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":12,"column":5},"source":"tap.equal(1, 1, '1 === 1')\n"}
+  ...
+not ok 3 - test point left in queue: ok - expect truthy value
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":13,"column":5},"source":"tap.ok('this is ok')\n"}
+  ...
+not ok 4 - test point left in queue: not ok - failsome
+  ---
+  {"hoo":"hah","at":{"file":"test/test/unfinished.js","line":14,"column":5},"source":"tap.fail('failsome', { hoo: 'hah' })\n"}
+  ...
+not ok 5 - spawn left in queue
+  ---
+  {"rar":"grr","at":{"file":"test/test/unfinished.js","line":16,"column":5},"command":"node","args":["___/.*/~~~unfinished.js"],"options":{},"name":"spawny","source":"tap.spawn('node', [__filename], {}, 'spawny', { rar: 'grr' })\n"}
+  ...
+not ok 6 - child test left in queue
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":18,"column":5},"source":"tap.test(function(t) {\n"}
+  ...
+not ok 7 - child test left in queue
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":24,"column":5},"source":"tap.test('', function(t) {\n"}
+  ...
+not ok 8 - child test left in queue
+  ---
+  {"at":{"file":"test/test/unfinished.js","line":30,"column":5},"name":"t2","source":"tap.test('t2', function(t) {\n"}
+  ...
+1..8
+# failed 8 of 8 tests
 ___/# time=[0-9.]+(ms)?/~~~
 


### PR DESCRIPTION
Fix #161
Fix #152
Re #129

This is a pretty significant change.  It may introduce some annoying
test failures in some cases, but most likely, those are tests that were
silently being ignored before.

Now, when `t.endAll()` is called, if there's anything waiting in the
queue, it will be treated as a failure, and reported with extreme
prejudice.  It should be virtually impossible after this change to ever
have a test simply be ignored or have the tap stream cut off after
starting a new child test.

r? @sam-github @rmg
