### PR TITLE
Add support for running tests via babel, with source-mapped stack traces

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var args = process.argv.slice(2)
 
+var path = require('path')
 var fs = require('fs')
 if (!args.length && process.stdin.isTTY) {
   console.error(usage())
@@ -34,6 +35,7 @@ var reporter
 var files = []
 var bail = false
 var saveFile = null
+var useBabel = false
 
 var singleFlags = {
   b: 'bail',
@@ -161,6 +163,10 @@ for (var i = 0; i < args.length; i++) {
       nodeArgs.push('--harmony')
       continue
 
+    case '--babel':
+      useBabel = true
+      continue
+      
     case '--color':
       color = true
       continue
@@ -413,8 +419,10 @@ for (var i = 0; i < files.length; i++) {
 
   extra.file = file
 
+  target = useBabel ? [path.resolve(__dirname, '../lib/babel-wrap.js'), file] : file
+  
   if (file.match(/\.js$/))
-    tap.spawn(process.execPath, nodeArgs.concat(file), opt, file, extra)
+    tap.spawn(process.execPath, nodeArgs.concat(target), opt, file, extra)
   else if (st.isDirectory()) {
     files.push.apply(files, fs.readdirSync(file).map(function (f) {
       return file + '/' + f

--- a/lib/babel-wrap.js
+++ b/lib/babel-wrap.js
@@ -1,0 +1,15 @@
+var path = require('path')
+
+// remove ourselves from process.argv
+var idx = process.argv.indexOf(__filename)
+if (idx > -1) process.argv.splice(idx, 1)
+
+// install source maps so that stack dumps will be correct
+require('source-map-support').install()
+
+// install babel
+require('babel/register')
+
+// require the original target file, export its exports
+var fullpath = path.join(process.cwd(), process.argv[1])
+module.exports = require(fullpath)

--- a/lib/babel-wrap.js
+++ b/lib/babel-wrap.js
@@ -1,8 +1,7 @@
 var path = require('path')
 
 // remove ourselves from process.argv
-var idx = process.argv.indexOf(__filename)
-if (idx > -1) process.argv.splice(idx, 1)
+process.argv.splice(1, 1)
 
 // install source maps so that stack dumps will be correct
 require('source-map-support').install()

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "lib/assert.js",
+    "lib/babel-wrap.js",
     "lib/mocha.js",
     "lib/root.js",
     "lib/stack.js",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": ">=0.8"
   },
   "dependencies": {
+    "babel": "^5.8.23",
     "coveralls": "^2.11.2",
     "deeper": "^2.1.0",
     "foreground-child": "^1.2.0",
@@ -22,6 +23,7 @@
     "opener": "^1.4.1",
     "readable-stream": "^2.0.2",
     "signal-exit": "^2.0.0",
+    "source-map-support": "^0.3.2",
     "supports-color": "^1.3.1",
     "tap-mocha-reporter": "0.0 || 1",
     "tap-parser": "^1.0.1"


### PR DESCRIPTION
I don't know if this is something you'll want or not, but it's here if you do. I had a choice of shimming it at `Test#spawn` or in `run.js`, but chose the latter since the former is an external api and would require me to parse arguments to the node command line in a way I'm not sure would be very robust.
