### PR TITLE
Allow cleanup code to run in process.exit

### DIFF
--- a/lib/root.js
+++ b/lib/root.js
@@ -16,8 +16,16 @@ tap.on('bailout', function () {
 process.on('exit', function (code) {
   tap.endAll()
 
-  if (!tap._ok && code === 0)
-    process.exit(1)
+  if (!tap._ok && code === 0) {
+    // `process.exitCode` was added in node 0.12.
+    // https://github.com/nodejs/node/commit/a5dba82ee210685ffce17b35ff2da9cca1d268d2
+    if (/^v(0\.12|[1-9])/.test(process.version)) {
+      // Allow cleanup code in other process#exit handlers to run.
+      process.exitCode = 1
+    } else {
+      process.exit(1)
+    }
+  }
 })
 
 // need to autoend if a teardown is added.

--- a/test/exit-code.js
+++ b/test/exit-code.js
@@ -6,7 +6,7 @@ var path = require('path')
 var fixtures = path.resolve(__dirname, 'fixtures')
 
 test('exit code 1 when tap results show failure', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   t.test('test exits 0, has failures', function (t) {
     t.plan(2)
@@ -38,6 +38,21 @@ test('exit code 1 when tap results show failure', function (t) {
     })
     spawn(node, [file]).on('exit', function (code) {
       t.equal(code, 1)
+    })
+  })
+
+  t.test('test sets custom exit code (2) in process#exit handler', function (t) {
+    if (!/^v(0\.12|[1-9])/.test(process.version)) {
+      t.comment('Skip on node 0.x because process.exitCode isn\'t supported')
+      return t.end()
+    }
+
+    t.plan(1)
+    var file = path.resolve(fixtures, 'fail-custom-exit-code.js')
+    spawn(node, [file]).on('exit', function (code) {
+      // The exit code is just a proxy for the fact that the process.on('exit')
+      // handler was executed.
+      t.equal(code, 2, 'executes the exit handler')
     })
   })
 })

--- a/test/fixtures/fail-custom-exit-code.js
+++ b/test/fixtures/fail-custom-exit-code.js
@@ -1,0 +1,10 @@
+var tap = require('../../')
+
+process.on('exit', function() {
+  process.exit(2)
+})
+
+tap.test(function(t) {
+  t.equal(1, 2, 'trigger test failure')
+  t.end()
+})


### PR DESCRIPTION
While trying to add `tap`-support for our [integration test tool](https://github.com/groupon/testium) we ran into problems with leaking processes. It comes down to the following pseudo-code:

``` js
var tap = require('tap')

// ... somewhere in another module
var child = spawn('phanomjs')
process.on('exit', function() { child.kill() })

// back in the test code
tap.test('some failing test', function(t) {
  t.equal(1, 2)
  t.end() // oops, `child` will never exit
})
```

I'm not sure how to solve this problem for node 0.10 and before but starting with 0.12 `tap` could use `process.exitCode` instead of calling `process.exit` which lets other `process#exit` listeners run and (for us) fixes everything.
