### PR TITLE
Protect against out-of-bound line numbers

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1031,7 +1031,7 @@ Test.prototype.writeDiags = function (extra) {
       content = Module.wrap(fs.readFileSync(file))
     } catch (er) {}
     if (content) {
-      content = content.split('\n')[extra.at.line - 1].trim()
+      content = (content.split('\n')[extra.at.line - 1] || '').trim()
       if (content)
         extra.source = content + '\n'
     }

--- a/test/fixtures/using-require-hook.faux
+++ b/test/fixtures/using-require-hook.faux
@@ -1,0 +1,1 @@
+The actual content of this file is ignored.

--- a/test/fixtures/using-require-hook.js
+++ b/test/fixtures/using-require-hook.js
@@ -1,0 +1,19 @@
+// We're simulating that some test failed in `using-require-hook.faux`
+// which was compiled to a js module with more lines than the file on disk.
+var Module = require('module')
+var path = require('path')
+
+var filename = path.resolve(__dirname, 'using-require-hook.faux')
+var m = new Module(filename, module)
+m.filename = filename
+m.paths = Module._nodeModulePaths(path.dirname(filename))
+m._compile('(' + runTapTest.toString() + ')()', filename)
+
+function runTapTest() {
+  var tap = require('../..');
+
+  tap.test(function(t) {
+    t.plan(1)
+    t.equal(1, 2) // failing test so tap tries to find the source code
+  })
+}

--- a/test/require-hooks.js
+++ b/test/require-hooks.js
@@ -1,0 +1,26 @@
+var execFile = require('child_process').execFile
+var node = process.execPath
+var bin = require.resolve('../bin/run.js')
+var test = require('../').test
+var path = require('path')
+var fixtures = path.resolve(__dirname, 'fixtures')
+
+test('compile-to-js require hook', function (t) {
+  t.plan(1)
+
+  t.test('failing test with unmatched stack-trace', function (t) {
+    t.plan(6)
+
+    function verifyOutput(err, stdout, stderr) {
+      t.ok(!!err, 'Should have failed to run')
+      t.ok(stdout.indexOf('file: test/fixtures/using-require-hook.faux') !== -1,
+        'error happened in the *.faux file')
+      t.ok(stdout.indexOf('source:') === -1,
+        'omits the source because the line cannot be resolved')
+    }
+
+    var file = path.resolve(fixtures, 'using-require-hook.js')
+    execFile(node, [bin, file], verifyOutput)
+    execFile(node, [file], verifyOutput)
+  })
+})


### PR DESCRIPTION
When using require hooks (e.g. `babel-node`), the stack positions of a test failure do not necessarily resolve to a valid line in the file on disk. This change gracefully ignores them. A better fix might be to get source mappings for babel/coffee/etc. working but this prevents crashes at least.
