### PR TITLE
Add automatic Codecov.io support

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -48,7 +48,10 @@ Options:
                               If a COVERALLS_REPO_TOKEN environment
                               variable is set, then coverage is
                               captured by default and sent to the
-                              coveralls.io service.
+                              coveralls.io service. If a CODECOV_TOKEN
+                              environment variable is set, then coverage is
+                              captured by default and sent to the
+                              codecov.io service.
 
   --no-coverage --no-cov      Do not capture coverage information.
                               Note that if nyc is already loaded, then
@@ -59,7 +62,7 @@ Options:
 
                               Default is 'text' when running on the
                               command line, or 'text-lcov' when piping
-                              to coveralls.
+                              to coveralls or codecov.
 
                               If 'lcov' is used, then the report will
                               be opened in a web browser after running.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": ">=0.8"
   },
   "dependencies": {
+    "codecov.io": "0.1.6",
     "coveralls": "^2.11.2",
     "deeper": "^2.1.0",
     "foreground-child": "^1.2.0",


### PR DESCRIPTION
Add support for piping coverage results to codecov.io via the
CODECOV_TOKEN environment variable.

Ref: https://github.com/isaacs/node-tap/issues/179

It does not include any tests as I wasn't sure how we wanted to go about testing the code coverage. Any input on that would be greatly appreciated.
