### PR TITLE
make t.throws match if regex is passed

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -213,8 +213,12 @@ function decorate (t) {
       // 'name' is a getter.
       if (er.name)
         er.name = er.name + ''
-      if (wanted)
+      if (wanted) {
+        if (Object.prototype.toString.call(wanted) === '[object RegExp]') {
+          return this.match(er.message, wanted, m, e)
+        }
         return this.has(er, wanted, m, e)
+      }
       else
         return this.pass(m, e)
     }

--- a/test/test/throws-bail.tap
+++ b/test/test/throws-bail.tap
@@ -1,0 +1,11 @@
+TAP version 13
+    # Subtest: throws should match a regex
+    1..2
+    ok 1 - expected to throw
+    not ok 2 - expected to throw
+      ---
+      {"at":{"column":5,"file":"test/test/throws.js","line":9},"found":"test","pattern":"/fasdfsadf/","source":"t.throws(function() {\n"}
+      ...
+    Bail out! # expected to throw
+Bail out! # expected to throw
+

--- a/test/test/throws.js
+++ b/test/test/throws.js
@@ -1,0 +1,12 @@
+var t = require('../..')
+
+t.test('throws should match a regex', function(t) {
+  t.plan(2)
+  t.throws(function() {
+    throw new Error('test')
+  }, /test/)
+
+  t.throws(function() {
+    throw new Error('test')
+  }, /fasdfsadf/)
+})

--- a/test/test/throws.tap
+++ b/test/test/throws.tap
@@ -1,0 +1,18 @@
+TAP version 13
+    # Subtest: throws should match a regex
+    1..2
+    ok 1 - expected to throw
+    not ok 2 - expected to throw
+      ---
+      {"at":{"column":5,"file":"test/test/throws.js","line":9},"found":"test","pattern":"/fasdfsadf/","source":"t.throws(function() {\n"}
+      ...
+    # failed 1 of 2 tests
+not ok 1 - throws should match a regex ___/# time=[0-9.]+(ms)?/~~~
+  ---
+  {"at":{"column":3,"file":"test/test/throws.js","line":3},"results":{"count":2,"fail":1,"ok":false,"pass":1,"plan":{"end":2,"start":1}},"source":"t.test('throws should match a regex', function(t) {\n"}
+  ...
+
+1..1
+# failed 1 of 1 tests
+___/# time=[0-9.]+(ms)?/~~~
+


### PR DESCRIPTION
The documentation states that "The expected error is tested against the throw error using `t.match`, so regular expressions and the like are fine.", but passing a regex as the second argument does not actual verify that it matches.

The following currently passes:

```
t.throws(function() {
  throw new Error('1')
}, /test/)
```

This change makes sure that the follow would instead fail as documented.
