### PR TITLE
Use function.name if name arg isn't provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ tap.test('must mostly succeed or all is lost', function (t) {
 // tests there will be in advance. Handy when
 // order is irrelevant and things happen in parallel.
 
-tap.test('planned test', function (t) {
+// Note that the function name is used if no name is provided!
+tap.test(function planned (t) {
   t.plan(2)
   setTimeout(function () {
     t.ok(true, 'a timeout')
@@ -82,15 +83,16 @@ tap.test('planned test', function (t) {
 var test = require('tap').test
 
 // subtests can have subtests
-test('parent', function (t) {
-  t.test('child', function (tt) {
+test(function parent (t) {
+  t.test(function child (tt) {
     tt.throws(function () {
       throw new Error('fooblz')
     }, {
       message: 'fooblz'
     }, 'throw a fooblz')
 
-    tt.throws(function () { throw 1 }, 'throw whatever')
+    // throws also uses function name if no name provided
+    tt.throws(function throw_whatever () { throw 1 })
 
     tt.end()
   })
@@ -341,12 +343,16 @@ their data to their parent, and the root `require('tap')` object pipes
 to stdout by default.  However, you can instantiate a `Test` object
 and then pipe it wherever you like.  The only limit is your imagination.
 
-#### t.test(name, [options], [function])
+#### t.test([name], [options], [function])
 
 Create a subtest.
 
 If the function is omitted, then it will be marked as a "todo" or
 "pending" test.
+
+If the function has a name, and no name is provided, then the function
+name will be used as the test name.  If no test name is provided, then
+the name will be `(unnamed test)`.
 
 The function gets a Test object as its only argument.  From there, you
 can call the `t.end()` method on that object to end the test, or use
@@ -491,6 +497,9 @@ Expect the function to throw an error.  If an expected error is
 provided, then also verify that the thrown error matches the expected
 error.
 
+If the function has a name, and the message is not provided, then the
+function name will be used as the message.
+
 Caveat: if you pass a `extra` object to t.throws, then you MUST also
 pass in an expected error, or else it will read the diag object as the
 expected error, and get upset when your thrown error doesn't match
@@ -521,6 +530,9 @@ Synonyms: `t.throw`
 #### t.doesNotThrow(fn, message, extra)
 
 Verify that the provided function does not throw.
+
+If the function has a name, and the message is not provided, then the
+function name will be used as the message.
 
 Note: if an error is encountered unexpectedly, it's often better to
 simply throw it.  The Test object will handle this as a failure.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -174,7 +174,9 @@ function decorate (t) {
       e[i] = e__[i]
     }
 
-    m = m || 'expected to throw'
+    if (!m)
+      m = fn && fn.name || 'expected to throw'
+
     if (wanted) {
       if (wanted instanceof Error) {
         var w = {
@@ -230,7 +232,10 @@ function decorate (t) {
       fn = m
       m = x
     }
-    m = m || 'expected to not throw'
+
+    if (!m)
+      m = fn && fn.name || 'expected to not throw'
+
     if (typeof fn !== 'function') {
       e.todo = true
       return this.pass(m, e)

--- a/lib/test.js
+++ b/lib/test.js
@@ -345,6 +345,9 @@ Test.prototype.test = function test (name, extra, cb) {
   } else if (typeof cb !== 'function')
     throw new Error('test() requires a callback')
 
+  if (!name && cb && cb.name)
+    name = cb.name
+
   if (extra.skip || extra.todo)
     return this.pass(name, extra)
 

--- a/test/test/ok.js
+++ b/test/test/ok.js
@@ -1,7 +1,7 @@
 var t = require('../..')
 var test = t.test
 
-test('nesting', function (t) {
+test(function nesting (t) {
   var plan = t.plan
   var test= t.test
   plan(2)

--- a/test/test/throws-bail.tap
+++ b/test/test/throws-bail.tap
@@ -1,11 +1,11 @@
 TAP version 13
     # Subtest: throws should match a regex
     1..2
-    ok 1 - expected to throw
-    not ok 2 - expected to throw
+    ok 1 - passing_thrower
+    not ok 2 - failing_thrower
       ---
-      {"at":{"column":5,"file":"test/test/throws.js","line":9},"found":"test","pattern":"/fasdfsadf/","source":"t.throws(function() {\n"}
+      {"at":{"column":5,"file":"test/test/throws.js","line":9},"found":"test","pattern":"/fasdfsadf/","source":"t.throws(function failing_thrower () {\n"}
       ...
-    Bail out! # expected to throw
-Bail out! # expected to throw
+    Bail out! # failing_thrower
+Bail out! # failing_thrower
 

--- a/test/test/throws.js
+++ b/test/test/throws.js
@@ -2,11 +2,11 @@ var t = require('../..')
 
 t.test('throws should match a regex', function(t) {
   t.plan(2)
-  t.throws(function() {
+  t.throws(function passing_thrower () {
     throw new Error('test')
   }, /test/)
 
-  t.throws(function() {
+  t.throws(function failing_thrower () {
     throw new Error('test')
   }, /fasdfsadf/)
 })

--- a/test/test/throws.tap
+++ b/test/test/throws.tap
@@ -1,10 +1,10 @@
 TAP version 13
     # Subtest: throws should match a regex
     1..2
-    ok 1 - expected to throw
-    not ok 2 - expected to throw
+    ok 1 - passing_thrower
+    not ok 2 - failing_thrower
       ---
-      {"at":{"column":5,"file":"test/test/throws.js","line":9},"found":"test","pattern":"/fasdfsadf/","source":"t.throws(function() {\n"}
+      {"at":{"column":5,"file":"test/test/throws.js","line":9},"found":"test","pattern":"/fasdfsadf/","source":"t.throws(function failing_thrower () {\n"}
       ...
     # failed 1 of 2 tests
 not ok 1 - throws should match a regex ___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/todo-bail.tap
+++ b/test/test/todo-bail.tap
@@ -17,13 +17,14 @@ TAP version 13
     1..3
 ok 1 - a set of tests to be done later ___/# time=[0-9.]+(ms)?/~~~
 
+ok 2 - (unnamed test) # TODO
     # Subtest: another set of tests
     ok 1 - is a second set # TODO
     ok 2 - looks like english # TODO
     ok 3 - is marked TODO # TODO
     1..3
-ok 2 - another set of tests ___/# time=[0-9.]+(ms)?/~~~
+ok 3 - another set of tests ___/# time=[0-9.]+(ms)?/~~~
 
-1..2
+1..3
 ___/# time=[0-9.]+(ms)?/~~~
 

--- a/test/test/todo.js
+++ b/test/test/todo.js
@@ -16,6 +16,9 @@ t.test('a set of tests to be done later', function (t) {
   t.end()
 })
 
+// literally nothing
+t.test()
+
 t.test('another set of tests', function (t) {
   t.test('is a second set')
   t.test('looks like english')

--- a/test/test/todo.tap
+++ b/test/test/todo.tap
@@ -17,13 +17,14 @@ TAP version 13
     1..3
 ok 1 - a set of tests to be done later ___/# time=[0-9.]+(ms)?/~~~
 
+ok 2 - (unnamed test) # TODO
     # Subtest: another set of tests
     ok 1 - is a second set # TODO
     ok 2 - looks like english # TODO
     ok 3 - is marked TODO # TODO
     1..3
-ok 2 - another set of tests ___/# time=[0-9.]+(ms)?/~~~
+ok 3 - another set of tests ___/# time=[0-9.]+(ms)?/~~~
 
-1..2
+1..3
 ___/# time=[0-9.]+(ms)?/~~~
 


### PR DESCRIPTION
This supports stuff like:

``` javascript
t.test(function someTestName (t) { ... })
```

I noticed some other test frameworks do this, and I think it's a cute API.  Super trivial to implement.
