### PR TITLE
Windows Support

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -52,8 +52,8 @@ function clean (stack) {
 
     return st.trim()
       .replace(/^\s*at /, '')
+      .replace(/\\/g, '/')
       .replace(cwd + '/', '')
-      .replace(cwd + '\\', '')
   }).filter(function (st) {
     return st
   }).join('\n').trim()
@@ -128,13 +128,14 @@ function at (fn) {
   }
 
   var res = {
-    file: site.getFileName(),
+    file: site.getFileName().replace(/\\/g, '/'),
     line: site.getLineNumber(),
     column: site.getColumnNumber()
   }
 
   if (res.file.indexOf(cwd + '/') === 0 ||
     res.file.indexOf(cwd + '\\') === 0) {
+    res.file = res.file.replace(/\\/g, '/')
     res.file = res.file.substr(cwd.length + 1)
   }
 
@@ -214,7 +215,7 @@ function parseLine (line) {
   var native = match[11] === 'native'
 
   var res = {
-    file: file,
+    file: file.replace(/\\/g, '/'),
     line: +lnum,
     column: +col
   }
@@ -222,7 +223,7 @@ function parseLine (line) {
   if (res.file &&
     (res.file.indexOf(cwd + '/') === 0 ||
     res.file.indexOf(cwd + '\\') === 0)) {
-    res.file = res.file.substr(cwd.length + 1)
+    res.file = res.file.substr(cwd.length + 1).replace(/\\/g, '/')
   }
 
   if (ctor) {
@@ -233,7 +234,7 @@ function parseLine (line) {
     res.evalOrigin = evalOrigin
     res.evalLine = evalLine
     res.evalColumn = evalCol
-    res.evalFile = evalFile
+    res.evalFile = evalFile.replace(/\\/g, '/')
   }
 
   if (native) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -666,7 +666,27 @@ Test.prototype.spawn = function spawnTest (cmd, args, options, name, extra) {
   }
 
   var start = process.hrtime()
-  var child = spawn(cmd, args, options)
+  try {
+    var child = spawn(cmd, args, options)
+  } catch (er) {
+    this.threw(er)
+    return
+  }
+
+  child.on('error', function (er) {
+    this.threw(er)
+
+    // unhook entirely
+    child.stdout.removeAllListeners('data')
+    child.stdout.removeAllListeners('end')
+    child.removeAllListeners('close')
+    this._currentChild = null
+    this._processQueue()
+
+    // just to be safe, kill the process
+    child.kill('SIGKILL')
+  }.bind(this))
+
   var parser = new Parser()
   var self = this
   this._currentChild = child

--- a/lib/test.js
+++ b/lib/test.js
@@ -806,7 +806,7 @@ Test.prototype.done = Test.prototype.end = function end (implicit) {
   }
 
   if (this._currentChild) {
-    this._queue.push(['end'])
+    this._queue.push(['end', implicit])
     return
   }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -605,7 +605,7 @@ Test.prototype.spawn = function spawnTest (cmd, args, options, name, extra) {
     if (cmd === process.execPath) {
       name = args.map(function (a) {
         if (a.indexOf(process.cwd()) === 0) {
-          return './' + a.substr(process.cwd().length + 1)
+          return './' + a.substr(process.cwd().length + 1).replace(/\\/g, '/')
         } else {
           return a
         }

--- a/lib/test.js
+++ b/lib/test.js
@@ -298,6 +298,11 @@ Test.prototype.threw = function threw (er, extra, proxy) {
   }
 
   this.fail(extra.message || er.message, extra)
+
+  // thrown errors cut to the front of the queue.
+  if (this._currentChild && this._queue.length) {
+    this._queue.unshift(this._queue.pop())
+  }
   if (!proxy) {
     this.end(IMPLICIT)
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "codecov.io": "^0.1.6",
     "coveralls": "^2.11.2",
     "deeper": "^2.1.0",
-    "foreground-child": "^1.2.0",
+    "foreground-child": "^1.3.3",
     "glob": "^6.0.1",
     "js-yaml": "^3.3.1",
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tap"
   ],
   "license": "ISC",
-  "repository": "https://github.com/isaacs/node-tap.git",
+  "repository": "https://github.com/tapjs/node-tap.git",
   "scripts": {
     "regen-fixtures": "node scripts/generate-test-test.js test/test/*.js",
     "test": "node bin/run.js test/*.* --coverage",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "glob": "^6.0.1",
     "js-yaml": "^3.3.1",
     "mkdirp": "^0.5.0",
-    "nyc": "^5.1.0",
+    "nyc": "github:isaacs/nyc",
     "only-shallow": "^1.0.2",
     "opener": "^1.4.1",
     "readable-stream": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "glob": "^6.0.1",
     "js-yaml": "^3.3.1",
     "mkdirp": "^0.5.0",
-    "nyc": "github:isaacs/nyc",
+    "nyc": "^5.2.0",
     "only-shallow": "^1.0.2",
     "opener": "^1.4.1",
     "readable-stream": "^2.0.2",

--- a/scripts/generate-test-test.js
+++ b/scripts/generate-test-test.js
@@ -53,8 +53,8 @@ function generate (file, bail) {
     output = output.split(node).join('\0N2\0')
     output = output.split(path.basename(node)).join('\0N2\0')
 
-    output = output.split('\0N1\0').join('___/.*(node|iojs)')
-    output = output.split('\0N2\0').join('___/.*(node|iojs)/~~~')
+    output = output.split('\0N1\0').join('___/.*(node|iojs)(\.exe)?')
+    output = output.split('\0N2\0').join('___/.*(node|iojs)(\.exe)?/~~~')
 
     output = yamlishToJson(output)
 

--- a/test/executable-scripts.js
+++ b/test/executable-scripts.js
@@ -1,0 +1,61 @@
+var t = require('../')
+
+if (process.platform === 'win32') {
+  t.plan(0, 'shebangs and exe bits are unix only')
+  process.exit(0)
+}
+
+var spawn = require('child_process').spawn
+var path = require('path')
+var fs = require('fs')
+var fixdir = path.resolve(__dirname, 'executable-scripts')
+var executed = path.resolve(fixdir, 'executed.sh')
+var notExecuted = path.resolve(fixdir, 'not-executed.sh')
+var run = require.resolve('../bin/run.js')
+var node = process.execPath
+
+function cleanup () {
+  try { fs.unlinkSync(executed) } catch (e) {}
+  try { fs.unlinkSync(notExecuted) } catch (e) {}
+  try { fs.rmdirSync(fixdir) } catch (e) {}
+}
+
+t.test('setup', function (t) {
+  cleanup()
+  fs.mkdirSync(fixdir, '0755')
+  fs.writeFileSync(
+    executed,
+    '#!/bin/sh\n' +
+    'echo 1..1\n' +
+    'echo ok 1 File with executable bit should be executed\n'
+  )
+  fs.chmodSync(executed, '0755')
+  fs.writeFileSync(
+    notExecuted,
+    '#!/bin/sh\n' +
+    'echo 1..1\n' +
+    'echo not ok 1 File without executable bit should not be run\n' +
+    'exit 1\n'
+  )
+  fs.chmodSync(notExecuted, '0644')
+  t.end()
+})
+
+t.test('run tap bin on shell scripts', function (t) {
+  var args = [run, fixdir, '--bail', '--no-color', '-Rtap']
+  var child = spawn(node, args)
+  var output = ''
+  child.stdout.on('data', function (c) {
+    output += c
+  })
+
+  child.on('close', function (code, signal) {
+    t.equal(code, 0, 'exit 0')
+    t.equal(signal, null, 'no signal exit')
+    t.notMatch(output, /not-executed\.sh/, 'not-executed.sh not seen')
+    t.match(output, /executed\.sh/, 'executed.sh was seen')
+    t.end()
+  })
+})
+
+t.tearDown(cleanup)

--- a/test/executed.sh
+++ b/test/executed.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-echo "1..1"
-echo "ok 1 File with executable bit should be executed"

--- a/test/expose-gc-test.js
+++ b/test/expose-gc-test.js
@@ -1,12 +1,16 @@
 var tap = require('../')
 var cp = require('child_process')
+var node = process.execPath
+var run = require.resolve('../bin/run.js')
 var path = require('path')
 var dir = path.resolve(__dirname, '..')
+var gcScript = require.resolve('./fixtures/gc-script.js')
 var opt = { cwd: dir }
 
 tap.test("gc test when the gc isn't there", function (t) {
   t.plan(1)
-  cp.exec('bin/run.js test/fixtures/gc-script.js', opt, function (err, stdo, stde) {
+  var args = [run, gcScript]
+  cp.execFile(node, args, opt, function (err, stdo, stde) {
     if (err) throw err
     t.equal(stde, 'false\n')
   })
@@ -17,7 +21,8 @@ tap.test('gc test when the gc should be there', function (t) {
   t.test('test for gc using --gc', function (t) {
     t.plan(1)
 
-    cp.exec('bin/run.js --gc test/fixtures/gc-script.js', opt, function (err, stdo, stde) {
+    var args = [run, '--gc', gcScript]
+    cp.execFile(node, args, opt, function (err, stdo, stde) {
       if (err) throw err
       t.equal(stde, 'true\n')
     })
@@ -26,7 +31,8 @@ tap.test('gc test when the gc should be there', function (t) {
   t.test('test for gc using --expose-gc', function (t) {
     t.plan(1)
 
-    cp.exec('bin/run.js --expose-gc test/fixtures/gc-script.js', opt, function (err, stdo, stde) {
+    var args = [run, '--expose-gc', gcScript]
+    cp.execFile(node, args, opt, function (err, stdo, stde) {
       if (err) throw err
       t.equal(stde, 'true\n')
     })

--- a/test/not-executed.sh
+++ b/test/not-executed.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "1..1"
-echo "not ok 1 File without executable bit should not be run"
-exit 1

--- a/test/only-non-tap-output.js
+++ b/test/only-non-tap-output.js
@@ -20,7 +20,7 @@ if (process.argv[2] === 'child') {
     t.has(tt._skips, [
       {
         ok: true,
-        message: './test/only-non-tap-output.js child',
+        message: /\.[\\\/]test[\\\/]only-non-tap-output.js child/,
         extra: {
           at: {},
           results: {},
@@ -31,7 +31,7 @@ if (process.argv[2] === 'child') {
       },
       {
         ok: true,
-        message: './test/only-non-tap-output.js silent',
+        message: /\.[\\\/]test[\\\/]only-non-tap-output.js silent/,
         extra: {
           at: {},
           results: {},

--- a/test/require-hooks.js
+++ b/test/require-hooks.js
@@ -14,7 +14,7 @@ test('compile-to-js require hook', function (t) {
 
     function verifyOutput (err, stdout, stderr) {
       t.ok(!!err, 'Should have failed to run')
-      t.match(stdout, 'file: test/fixtures/using-require-hook.faux',
+      t.match(stdout, /file: .*[\\\/]using-require-hook\.faux/,
         'error happened in the *.faux file')
       t.notMatch(stdout, 'source:',
         'omits the source because the line cannot be resolved')

--- a/test/runner.js
+++ b/test/runner.js
@@ -484,9 +484,14 @@ t.test('-t or --timeout to set timeout', function (t) {
         out += c
       })
       child.on('close', function (code, signal) {
+        var skip = process.platform === 'win32' && 'SIGTERM on windows is weird'
         t.equal(code, 1)
         t.equal(signal, null)
-        t.match(out, /received SIGTERM with pending event queue activity/)
+        t.match(
+          out,
+          /received SIGTERM with pending event queue activity/,
+          { skip: skip }
+        )
         t.end()
       })
     })

--- a/test/runner.js
+++ b/test/runner.js
@@ -326,7 +326,7 @@ t.test('unknown arg throws', function (t) {
   }
 })
 
-t.test('read from stdin', function (t) {
+t.test('read from stdin', { skip: process.platform === 'win32' && 'skip stdin test on windows' }, function (t) {
   function stripTime (s) {
     return s.split(ok).join('test/test/ok.js')
       .replace(/[0-9\.]+m?s/g, '{{TIME}}')

--- a/test/runner.js
+++ b/test/runner.js
@@ -260,6 +260,8 @@ t.test('version', function (t) {
   var skip = false
   if (!headBin) {
     skip = 'head program not available'
+  } else if (process.platform === 'win32') {
+    skip = 'signals on windows are weird'
   }
 
   t.test('handle EPIPE gracefully', { skip: skip }, function (t) {

--- a/test/runner.js
+++ b/test/runner.js
@@ -20,7 +20,7 @@ t.test('usage', function (t) {
     })
     child.on('close', function (code) {
       t.equal(code, c, 'code should be ' + c)
-      t.match(out, /^Usage:\n/, 'should print usage')
+      t.match(out, /^Usage:\r?\n/, 'should print usage')
       t.end()
     })
   }

--- a/test/segv.js
+++ b/test/segv.js
@@ -1,4 +1,8 @@
 var tap = require('../')
+if (process.platform === 'win32') {
+  tap.plan(0, 'skip on windows')
+  process.exit()
+}
 var test = tap.test
 var Test = tap.Test
 var fs = require('fs')

--- a/test/spawn-failures.js
+++ b/test/spawn-failures.js
@@ -1,0 +1,62 @@
+var cp = require('child_process')
+var spawn = cp.spawn
+cp.spawn = hijackedSpawn
+
+var throwNow = false
+var throwLater = false
+function hijackedSpawn (cmd, args, options) {
+  if (throwNow) {
+    throw throwNow
+  }
+  var child = spawn.call(cp, cmd, args, options)
+  if (throwLater) {
+    setTimeout(function () {
+      child.emit('error', throwLater)
+    })
+  }
+  return child
+}
+
+var t = require('../')
+var Test = t.Test
+var ok = require.resolve('./test/ok.js')
+
+t.test('handle throws from spawn()', function (t) {
+  throwNow = new Error('now is fine')
+
+  var output = ''
+  var tt = new Test()
+  tt.on('data', function (c) {
+    output += c
+  })
+  t.doesNotThrow(function spawn_throw_now () {
+    tt.spawn(process.execPath, [ok])
+  })
+  tt.end()
+  throwNow = false
+
+  t.comment(output)
+  t.notOk(tt.passing(), 'a failed spawn should fail the test')
+  t.end()
+})
+
+t.test('handle child process error event', function (t) {
+  throwLater = new Error('later is fine')
+
+  var output = ''
+  var tt = new Test()
+  tt.on('data', function (c) {
+    output += c
+  })
+  t.doesNotThrow(function spawn_throw_later () {
+    tt.spawn(process.execPath, [ok])
+  })
+  tt.end()
+
+  setTimeout(function () {
+    throwLater = false
+    t.comment(output)
+    t.notOk(tt.passing(), 'a failed spawn should fail the test')
+    t.end()
+  }, 100)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -24,8 +24,12 @@ if (process.argv[2]) {
 
 function runTest (file, bail) {
   var skip = false
-  if (file.match(/\bpending-handles.js$/) && process.env.TRAVIS) {
-    skip = 'pending handles test is too timing dependent for Travis'
+  if (file.match(/\bpending-handles.js$/)) {
+    if (process.env.TRAVIS) {
+      skip = 'pending handles test is too timing dependent for Travis'
+    } else if (process.platform === 'win32') {
+      skip = 'pending handles relies on sinals windows cannot do'
+    }
   }
 
   var resfile = file.replace(/\.js$/, (bail ? '-bail' : '') + '.tap')

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ function runTest (file, bail) {
 
   var resfile = file.replace(/\.js$/, (bail ? '-bail' : '') + '.tap')
   try {
-    var want = fs.readFileSync(resfile, 'utf8').split('\n')
+    var want = fs.readFileSync(resfile, 'utf8').split(/\r?\n/)
   } catch (er) {
     console.error(er)
     console.error(file)
@@ -54,7 +54,7 @@ function runTest (file, bail) {
       found += c
     })
     child.on('close', function (er) {
-      found = found.split('\n')
+      found = found.split(/\r?\n/)
       var inyaml = false
       var startlen = 0
       var y = ''

--- a/test/test/end-end.tap
+++ b/test/test/end-end.tap
@@ -15,28 +15,28 @@ ok 3 - end then async end ___/# time=[0-9.]+(ms)?/~~~
     1..0
 ok 4 - double async end ___/# time=[0-9.]+(ms)?/~~~
 
+not ok 5 - Error: test end() method called more than once
+  ---
+  {"message":"Error: test end() method called more than once","test":"end then async end"}
+  ...
     # Subtest: plan end
     1..1
     ok 1 - this is fine
-ok 5 - plan end ___/# time=[0-9.]+(ms)?/~~~
+ok 6 - plan end ___/# time=[0-9.]+(ms)?/~~~
 
     # Subtest: plan then async end
     1..1
     ok 1 - this is fine
-ok 6 - plan then async end ___/# time=[0-9.]+(ms)?/~~~
+ok 7 - plan then async end ___/# time=[0-9.]+(ms)?/~~~
 
     # Subtest: plan end end
     1..1
     ok 1 - this is fine
-ok 7 - plan end end ___/# time=[0-9.]+(ms)?/~~~
+ok 8 - plan end end ___/# time=[0-9.]+(ms)?/~~~
 
-not ok 8 - Error: test end() method called more than once
-  ---
-  {"message":"Error: test end() method called more than once","test":"plan end end"}
-  ...
 not ok 9 - Error: test end() method called more than once
   ---
-  {"message":"Error: test end() method called more than once","test":"end then async end"}
+  {"message":"Error: test end() method called more than once","test":"plan end end"}
   ...
 not ok 10 - Error: test end() method called more than once
   ---

--- a/test/test/pending-handles.tap
+++ b/test/test/pending-handles.tap
@@ -10,7 +10,7 @@ TAP version 13
     ___/# time=[0-9.]+(ms)?/~~~
 not ok 1 - ___/.*/~~~pending-handles.js child ___/# time=[0-9.]+(ms)?/~~~
   ---
-  {"arguments":["___/.*/~~~pending-handles.js","child"],"at":{"column":5,"file":"test/test/pending-handles.js","line":7},"command":"___/.*(node|iojs)/~~~","failure":"timeout","results":{"count":2,"fail":1,"ok":false,"pass":1,"plan":{"end":2,"start":1}},"signal":"SIGTERM","source":"t.spawn(process.execPath, [__filename, 'child'], {}, '', {\n","timeout":900}
+  {"arguments":["___/.*/~~~pending-handles.js","child"],"at":{"column":5,"file":"test/test/pending-handles.js","line":7},"command":"___/.*(node|iojs)(.exe)?/~~~","failure":"timeout","results":{"count":2,"fail":1,"ok":false,"pass":1,"plan":{"end":2,"start":1}},"signal":"SIGTERM","source":"t.spawn(process.execPath, [__filename, 'child'], {}, '', {\n","timeout":900}
   ...
 
 1..1

--- a/test/test/pragma-bail.tap
+++ b/test/test/pragma-bail.tap
@@ -11,7 +11,7 @@ TAP version 13
     ___/# time=[0-9.]+(ms)?/~~~
 not ok 1 - ___/.*/~~~pragma.js child ___/# time=[0-9.]+(ms)?/~~~
   ---
-  {"arguments":["___/.*/~~~pragma.js","child"],"at":{"column":5,"file":"test/test/pragma.js","line":4},"command":"___/.*(node|iojs)/~~~","results":{"count":2,"failures":[{"data":"this is not tap and it is not ok\n","tapError":"Non-TAP data encountered in strict mode"}],"ok":false,"pass":2,"plan":{"end":2,"start":1}},"source":"t.spawn(process.execPath, [__filename, 'child'])\n"}
+  {"arguments":["___/.*/~~~pragma.js","child"],"at":{"column":5,"file":"test/test/pragma.js","line":4},"command":"___/.*(node|iojs)(.exe)?/~~~","results":{"count":2,"failures":[{"data":"this is not tap and it is not ok\n","tapError":"Non-TAP data encountered in strict mode"}],"ok":false,"pass":2,"plan":{"end":2,"start":1}},"source":"t.spawn(process.execPath, [__filename, 'child'])\n"}
   ...
 Bail out! # ___/.*/~~~pragma.js child ___/# time=[0-9.]+(ms)?/~~~
 

--- a/test/test/pragma.tap
+++ b/test/test/pragma.tap
@@ -11,7 +11,7 @@ TAP version 13
     ___/# time=[0-9.]+(ms)?/~~~
 not ok 1 - ___/.*/~~~pragma.js child ___/# time=[0-9.]+(ms)?/~~~
   ---
-  {"arguments":["___/.*/~~~pragma.js","child"],"at":{"column":5,"file":"test/test/pragma.js","line":4},"command":"___/.*(node|iojs)/~~~","results":{"count":2,"failures":[{"data":"this is not tap and it is not ok\n","tapError":"Non-TAP data encountered in strict mode"}],"ok":false,"pass":2,"plan":{"end":2,"start":1}},"source":"t.spawn(process.execPath, [__filename, 'child'])\n"}
+  {"arguments":["___/.*/~~~pragma.js","child"],"at":{"column":5,"file":"test/test/pragma.js","line":4},"command":"___/.*(node|iojs)(.exe)?/~~~","results":{"count":2,"failures":[{"data":"this is not tap and it is not ok\n","tapError":"Non-TAP data encountered in strict mode"}],"ok":false,"pass":2,"plan":{"end":2,"start":1}},"source":"t.spawn(process.execPath, [__filename, 'child'])\n"}
   ...
 
 1..1

--- a/test/test/spawn-failures-bail.tap
+++ b/test/test/spawn-failures-bail.tap
@@ -1,0 +1,9 @@
+TAP version 13
+    # Subtest: spawn that throws
+    not ok 1 - Error: now is fine
+      ---
+      {"at":{"column":14,"file":"test/test/spawn-failures.js","line":25},"message":"Error: now is fine","source":"throwNow = new Error('now is fine')\n","test":"spawn that throws"}
+      ...
+    Bail out! # Error: now is fine
+Bail out! # Error: now is fine
+

--- a/test/test/spawn-failures.js
+++ b/test/test/spawn-failures.js
@@ -1,0 +1,40 @@
+var cp = require('child_process')
+var spawn = cp.spawn
+cp.spawn = hijackedSpawn
+
+var throwNow = false
+var throwLater = false
+function hijackedSpawn (cmd, args, options) {
+  if (throwNow) {
+    throw throwNow
+  }
+  var child = spawn.call(cp, cmd, args, options)
+  if (throwLater) {
+    setTimeout(function () {
+      child.emit('error', throwLater)
+    })
+  }
+  return child
+}
+
+var t = require('../..')
+var ok = require.resolve('./ok.js')
+var node = process.execPath
+
+t.test('spawn that throws', function (t) {
+  throwNow = new Error('now is fine')
+  t.tearDown(function () {
+    throwNow = false
+  })
+  t.spawn(node, [ok])
+  t.end()
+})
+
+t.test('spawn that throws', function (t) {
+  throwLater = new Error('later is fine')
+  t.tearDown(function () {
+    throwLater = false
+  })
+  t.spawn(node, [ok])
+  t.end()
+})

--- a/test/test/spawn-failures.tap
+++ b/test/test/spawn-failures.tap
@@ -1,0 +1,30 @@
+TAP version 13
+    # Subtest: spawn that throws
+    not ok 1 - Error: now is fine
+      ---
+      {"at":{"column":14,"file":"test/test/spawn-failures.js","line":25},"message":"Error: now is fine","source":"throwNow = new Error('now is fine')\n","test":"spawn that throws"}
+      ...
+    1..1
+    # failed 1 of 1 tests
+not ok 1 - spawn that throws ___/# time=[0-9.]+(ms)?/~~~
+  ---
+  {"at":{"column":3,"file":"test/test/spawn-failures.js","line":24},"results":{"count":1,"fail":1,"ok":false,"pass":0,"plan":{"end":1,"start":1}},"source":"t.test('spawn that throws', function (t) {\n"}
+  ...
+
+    # Subtest: spawn that throws
+        # Subtest: ./test/test/ok.js
+    not ok 1 - Error: later is fine
+      ---
+      {"at":{"column":16,"file":"test/test/spawn-failures.js","line":34},"message":"Error: later is fine","source":"throwLater = new Error('later is fine')\n","test":"spawn that throws"}
+      ...
+    1..1
+    # failed 1 of 1 tests
+not ok 2 - spawn that throws ___/# time=[0-9.]+(ms)?/~~~
+  ---
+  {"at":{"column":3,"file":"test/test/spawn-failures.js","line":33},"results":{"count":1,"fail":1,"ok":false,"pass":0,"plan":{"end":1,"start":1}},"source":"t.test('spawn that throws', function (t) {\n"}
+  ...
+
+1..2
+# failed 2 of 2 tests
+___/# time=[0-9.]+(ms)?/~~~
+

--- a/test/test/spawn.tap
+++ b/test/test/spawn.tap
@@ -51,7 +51,7 @@ TAP version 13
     ___/# time=[0-9.]+(ms)?/~~~
 not ok 1 - ___/.*/~~~spawn.js child ___/# time=[0-9.]+(ms)?/~~~
   ---
-  {"arguments":["___/.*/~~~spawn.js","child"],"at":{"column":5,"file":"test/test/spawn.js","line":8},"command":"___/.*(node|iojs)/~~~","results":{"count":5,"fail":3,"ok":false,"pass":2,"plan":{"end":5,"start":1}},"source":"t.spawn(process.execPath, [__filename, 'child'])\n"}
+  {"arguments":["___/.*/~~~spawn.js","child"],"at":{"column":5,"file":"test/test/spawn.js","line":8},"command":"___/.*(node|iojs)(.exe)?/~~~","results":{"count":5,"fail":3,"ok":false,"pass":2,"plan":{"end":5,"start":1}},"source":"t.spawn(process.execPath, [__filename, 'child'])\n"}
   ...
 
     # Subtest: nesting

--- a/test/test/unfinished.tap
+++ b/test/test/unfinished.tap
@@ -37,11 +37,11 @@ not ok 4 - test point left in queue: not ok - failsome
   ...
 not ok 5 - spawn left in queue: spawny
   ---
-  {"args":["___/.*/~~~unfinished.js"],"at":{"column":5,"file":"test/test/unfinished.js","line":25},"command":"___/.*(node|iojs)/~~~","options":{},"rar":"grr","source":"tap.spawn('___/.*(node|iojs)/~~~', [__filename], {}, 'spawny', { rar: 'grr' })\n"}
+  {"args":["___/.*/~~~unfinished.js"],"at":{"column":5,"file":"test/test/unfinished.js","line":25},"command":"___/.*(node|iojs)(.exe)?/~~~","options":{},"rar":"grr","source":"tap.spawn('___/.*(node|iojs)(.exe)?/~~~', [__filename], {}, 'spawny', { rar: 'grr' })\n"}
   ...
-not ok 6 - spawn left in queue: ___/.*(node|iojs)/~~~ --version
+not ok 6 - spawn left in queue: ___/.*(node|iojs)(.exe)?/~~~ --version
   ---
-  {"args":["--version"],"at":{"column":5,"file":"test/test/unfinished.js","line":26},"command":"___/.*(node|iojs)/~~~","options":{},"rar":"grr","source":"tap.spawn('___/.*(node|iojs)/~~~', ['--version'], {}, '', { rar: 'grr' })\n"}
+  {"args":["--version"],"at":{"column":5,"file":"test/test/unfinished.js","line":26},"command":"___/.*(node|iojs)(.exe)?/~~~","options":{},"rar":"grr","source":"tap.spawn('___/.*(node|iojs)(.exe)?/~~~', ['--version'], {}, '', { rar: 'grr' })\n"}
   ...
 not ok 7 - child test left in queue: (unnamed)
   ---


### PR DESCRIPTION
This makes all tests either pass or explicitly skipped on Windows.

Fixes #202.

Relevant changes:
- Errors in spawned child process tests are no longer silently ignored (either throws in the `spawn()` call, or `error` events on the child proc itself.)
- Slashes are always `/`, pretty much everywhere.
- Thrown errors "jump the queue" so that they're guaranteed to be the next thing processed.
