### PR TITLE
bump stack-utils to 0.3.0

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -2,6 +2,6 @@ var StackUtils = require('stack-utils')
 
 module.exports = new StackUtils({
   internals: StackUtils.nodeInternals().concat([
-    /node_modules[\\\/]tap[\\\/](.*?)\.js:[0-9]:[0-9]\)?$/
+    /node_modules\/tap\/(.*?)\.js:[0-9]:[0-9]\)?$/
   ])
 })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "opener": "^1.4.1",
     "readable-stream": "^2.0.2",
     "signal-exit": "^2.0.0",
-    "stack-utils": "^0.2.0",
+    "stack-utils": "^0.3.0",
     "supports-color": "^1.3.1",
     "tap-mocha-reporter": "0.0 || 1",
     "tap-parser": "^1.2.2",

--- a/test/segv.c
+++ b/test/segv.c
@@ -1,0 +1,4 @@
+int main (void) {
+   char *s = "hello world";
+   *s = 'H';
+}


### PR DESCRIPTION
stack-utils now normalizes to unix path separators _before_ appling the `internals` filter. Regexps no longer need to account for backslashes.

stack-utils@0.3.0 also brings long-stack-trace support

https://github.com/tapjs/stack-utils/releases/tag/v0.3.0
