### PR TITLE
upgrade nyc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "glob": "^6.0.1",
     "isexe": "^1.0.0",
     "js-yaml": "^3.3.1",
-    "nyc": "isaacs/nyc",
+    "nyc": "^5.5.0",
     "only-shallow": "^1.0.2",
     "opener": "^1.4.1",
     "readable-stream": "^2.0.2",


### PR DESCRIPTION
the `master` branch of nyc has now landed the updates that had lead to a fork.
