### PR TITLE
Updated codecov dependency with "blessed" package.

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -29,7 +29,7 @@ var coverageServices = [
   },
   {
     env: 'CODECOV_TOKEN',
-    bin: require.resolve('codecov.io/bin/codecov.io.js'),
+    bin: require.resolve('codecov/bin/codecov'),
     name: 'Codecov'
   }
 ]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "clean-yaml-object": "^0.1.0",
-    "codecov.io": "^0.1.6",
+    "codecov": "^1.0.1",
     "coveralls": "^2.11.2",
     "deeper": "^2.1.0",
     "foreground-child": "^1.3.3",


### PR DESCRIPTION
codecov.io@0.1.6 -> codecov@1.0.1

One of the reasons:

![stale package](http://ia.gs/f5Tf/Image%202016-02-08%20at%201.34.31%20AM.png)

And `codecov` is what they have on their page:

![blessed package](http://ia.gs/f5aW/Image%202016-02-08%20at%202.18.43%20AM.png)
