### PR TITLE
Wait for returned promises before ending tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -83,7 +83,8 @@ function Test (options) {
   this._currentChild = null
   this._ending = false
   this._ended = false
-  this._planFinished = false
+  this._mustDeferEnd = false
+  this._deferredEnd = null
 
   this._parent = null
   this._printedVersion = false
@@ -550,14 +551,28 @@ Test.prototype._runChild = function runChild (child, name, extra, cb) {
 
   // still need try/catch for synchronous errors
   try {
+    child._mustDeferEnd = true;
     var cbRet = cb(child)
     if (cbRet && typeof cbRet.then === 'function') {
       // promise
       cbRet.then(function () {
-        child.end(IMPLICIT)
-      }, child.threw)
+        child._mustDeferEnd = false;
+        if (!child._tryResumeEnd()) {
+          child.end(IMPLICIT)
+        }
+      }, function (err) {
+        child._mustDeferEnd = false;
+        if (!child._tryResumeEnd()) {
+          child.threw(err)
+        }
+      })
+    } else {
+      child._mustDeferEnd = false;
+      child._tryResumeEnd()
     }
   } catch (er) {
+    child._mustDeferEnd = false;
+    child._tryResumeEnd()
     child.threw(er)
   }
   self._level = self
@@ -968,6 +983,14 @@ Test.prototype.done = Test.prototype.end = function end (implicit) {
     return
   }
 
+  // Repeated end() calls should be run once any deferred ends have finished.
+  if (this._deferredEnd) {
+    this._deferredEnd.after.push(function () {
+      this.end(implicit)
+    })
+    return
+  }
+
   if (implicit !== IMPLICIT && !this._multiEndThrew) {
     if (this._explicitEnded) {
       this._multiEndThrew = true
@@ -981,6 +1004,20 @@ Test.prototype.done = Test.prototype.end = function end (implicit) {
     return
   }
 
+  // If neccessary defer the end until the child callback has returned.
+  if (this._mustDeferEnd) {
+    this._deferredEnd = {
+      implicit: implicit,
+      plan: this._plan === -1 ? this._count : this._plan,
+      after: []
+    }
+    return
+  }
+
+  this._finishEnd(implicit);
+}
+
+Test.prototype._finishEnd = function (implicit) {
   // If the afterEach function throws, then we can end up back here
   if (this._ranAfterEach || !this._parent) {
     this._end(implicit)
@@ -1088,6 +1125,23 @@ Test.prototype._end = function (implicit) {
   }
 }
 
+Test.prototype._tryResumeEnd = function () {
+  if (!this._deferredEnd) {
+    return false
+  }
+
+  var implicit = this._deferredEnd.implicit
+  var after = this._deferredEnd.after
+  this._deferredEnd = null
+
+  this._finishEnd(implicit)
+  after.forEach(function (fn) {
+    fn.call(this)
+  }, this)
+
+  return true
+}
+
 Test.prototype._processQueue = function () {
   if (this._bailedOut) {
     return
@@ -1166,10 +1220,10 @@ Test.prototype.printResult = function printResult (ok, message, extra) {
   extra = extra || {}
 
   var n = this._count + 1
-  if (this._plan !== -1 && n > this._plan) {
+  if (this._plan !== -1 && n > this._plan || this._deferredEnd) {
     // Don't over-report failures.
     // it's already had problems, just ignore this.
-    if (!this._ok) {
+    if (!this._ok || this._deferredEnd && this._deferredEnd.after.length > 0) {
       return
     }
 
@@ -1189,8 +1243,17 @@ Test.prototype.printResult = function printResult (ok, message, extra) {
     }
     er.test = name
     er.count = n
-    er.plan = this._plan
-    this.threw(er)
+    // Only throw the failure once the deferred end has finished.
+    if (this._deferredEnd) {
+      er.plan = this._deferredEnd.plan
+      extra = this._extraFromError(er)
+      this._deferredEnd.after.push(function () {
+        this._parent.threw(er, extra, true)
+      })
+    } else {
+      er.plan = this._plan
+      this.threw(er)
+    }
     return
   }
 
@@ -1381,7 +1444,11 @@ Test.prototype.fail = function fail (message, extra) {
 
   var ret = true
   if (!extra.todo && !extra.skip) {
-    this._ok = ret = false
+    ret = false
+    // Don't modify test state when there's a deferred end.
+    if (!this._deferredEnd) {
+      this._ok = false
+    }
   }
 
   return ret

--- a/test/test/bailout-bail.tap
+++ b/test/test/bailout-bail.tap
@@ -12,6 +12,7 @@ TAP version 13
         ok 2 - this passes
         1..2
     ok 2 - second ___/# time=[0-9.]+(ms)?/~~~
+
 ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
 
 ok 2 - this passes

--- a/test/test/bailout.tap
+++ b/test/test/bailout.tap
@@ -12,6 +12,7 @@ TAP version 13
         ok 2 - this passes
         1..2
     ok 2 - second ___/# time=[0-9.]+(ms)?/~~~
+
 ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
 
 ok 2 - this passes

--- a/test/test/before-after-each-plan-bail.tap
+++ b/test/test/before-after-each-plan-bail.tap
@@ -15,9 +15,11 @@ before 2 grandchild
 after 2 grandchild
 after 1 grandchild
         ok 1 - grandchild ___/# time=[0-9.]+(ms)?/~~~
+
 after 2 child
 after 1 child
     ok 1 - child ___/# time=[0-9.]+(ms)?/~~~
+
 after 1 parent
 ok 1 - parent ___/# time=[0-9.]+(ms)?/~~~
 ___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/before-after-each-plan.tap
+++ b/test/test/before-after-each-plan.tap
@@ -15,9 +15,11 @@ before 2 grandchild
 after 2 grandchild
 after 1 grandchild
         ok 1 - grandchild ___/# time=[0-9.]+(ms)?/~~~
+
 after 2 child
 after 1 child
     ok 1 - child ___/# time=[0-9.]+(ms)?/~~~
+
 after 1 parent
 ok 1 - parent ___/# time=[0-9.]+(ms)?/~~~
 ___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/console-log-bail.tap
+++ b/test/test/console-log-bail.tap
@@ -18,9 +18,10 @@ TAP version 13
         ok 4 - nested ok second
         1..4
     ok 2 - second ___/# time=[0-9.]+(ms)?/~~~
-ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
 
 >>>> after second child
+ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
+
 >>>> after child test
 ok 2 - this passes
 ok 3 - this passes too

--- a/test/test/console-log.tap
+++ b/test/test/console-log.tap
@@ -18,9 +18,10 @@ TAP version 13
         ok 4 - nested ok second
         1..4
     ok 2 - second ___/# time=[0-9.]+(ms)?/~~~
-ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
 
 >>>> after second child
+ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
+
 >>>> after child test
 ok 2 - this passes
 ok 3 - this passes too

--- a/test/test/nesting.tap
+++ b/test/test/nesting.tap
@@ -20,6 +20,7 @@ TAP version 13
       ---
       {"at":{"column":5,"file":"test/test/nesting.js","line":10},"results":{"count":3,"fail":1,"ok":false,"pass":2,"plan":{"end":3,"start":1}},"source":"t.test('second', function (tt) {\n"}
       ...
+
     # failed 1 of 2 tests
 not ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
   ---

--- a/test/test/not-ok-nested.tap
+++ b/test/test/not-ok-nested.tap
@@ -12,6 +12,7 @@ TAP version 13
       ---
       {"at":{"column":5,"file":"test/test/not-ok-nested.js","line":5},"results":{"count":1,"fail":1,"ok":false,"pass":0,"plan":{"end":1,"start":1}},"source":"t.test('parent', function (t) {\n"}
       ...
+
     # failed 1 of 1 tests
 not ok 1 - gp ___/# time=[0-9.]+(ms)?/~~~
   ---

--- a/test/test/ok-bail.tap
+++ b/test/test/ok-bail.tap
@@ -13,6 +13,7 @@ TAP version 13
         ok 3 - nested ok
         1..3
     ok 2 - second ___/# time=[0-9.]+(ms)?/~~~
+
 ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
 
 ok 2 - this passes

--- a/test/test/ok.tap
+++ b/test/test/ok.tap
@@ -13,6 +13,7 @@ TAP version 13
         ok 3 - nested ok
         1..3
     ok 2 - second ___/# time=[0-9.]+(ms)?/~~~
+
 ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
 
 ok 2 - this passes

--- a/test/test/promise-plan-bail.tap
+++ b/test/test/promise-plan-bail.tap
@@ -1,0 +1,20 @@
+TAP version 13
+    # Subtest: one
+running one
+    1..1
+    ok 1 - done one
+ok 1 - one ___/# time=[0-9.]+(ms)?/~~~
+
+    # Subtest: two
+running two
+    1..1
+    ok 1 - done two
+ok 2 - two ___/# time=[0-9.]+(ms)?/~~~
+
+    # Subtest: three
+running three
+    1..0
+ok 3 - three ___/# time=[0-9.]+(ms)?/~~~
+
+1..3
+___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/promise-plan.js
+++ b/test/test/promise-plan.js
@@ -1,0 +1,31 @@
+var t = require('../..')
+var P = typeof Promise === 'undefined' ? require('bluebird') : Promise
+
+t.test('one', function (t) {
+  console.log('running one')
+  t.plan(1)
+
+  return new P(function (resolve) {
+    setTimeout(resolve, 50)
+    t.pass('done one')
+  }).then(function () {
+    console.error('one promise was fulfilled')
+  })
+})
+
+t.test('two', function (t) {
+  console.log('running two')
+  t.plan(1)
+
+  return new P(function (resolve) {
+    setTimeout(resolve, 50)
+  }).then(function () {
+    t.pass('done two')
+    console.error('two promise was fulfilled')
+  })
+})
+
+t.test('three', function (t) {
+  console.log('running three')
+  t.end()
+})

--- a/test/test/promise-plan.tap
+++ b/test/test/promise-plan.tap
@@ -1,0 +1,20 @@
+TAP version 13
+    # Subtest: one
+running one
+    1..1
+    ok 1 - done one
+ok 1 - one ___/# time=[0-9.]+(ms)?/~~~
+
+    # Subtest: two
+running two
+    1..1
+    ok 1 - done two
+ok 2 - two ___/# time=[0-9.]+(ms)?/~~~
+
+    # Subtest: three
+running three
+    1..0
+ok 3 - three ___/# time=[0-9.]+(ms)?/~~~
+
+1..3
+___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/spawn.tap
+++ b/test/test/spawn.tap
@@ -21,6 +21,7 @@ TAP version 13
           ---
           {"at":{"column":5,"file":"test/test/spawn.js","line":18},"results":{"count":3,"fail":1,"ok":false,"pass":2,"plan":{"end":3,"start":1}},"source":"t.test('second', function (tt) {\n"}
           ...
+
         # failed 1 of 2 tests
     not ok 1 - nesting ___/# time=[0-9.]+(ms)?/~~~
       ---
@@ -75,6 +76,7 @@ not ok 1 - ___/.*/~~~spawn.js child ___/# time=[0-9.]+(ms)?/~~~
       ---
       {"at":{"column":5,"file":"test/test/spawn.js","line":18},"results":{"count":3,"fail":1,"ok":false,"pass":2,"plan":{"end":3,"start":1}},"source":"t.test('second', function (tt) {\n"}
       ...
+
     # failed 1 of 2 tests
 not ok 2 - nesting ___/# time=[0-9.]+(ms)?/~~~
   ---


### PR DESCRIPTION
Fixes #240.

If a promise is returned then that promise should dictate the test lifecycle. This prevents tests from ending prematurely when a planned assertion count is reached, but further work takes place before the returned promise is fulfilled (or indeed rejected).

This commit defers ending the test until the test function has returned. Care is taken to ensure that ending tests more that once, exceeding the planned assertion count, or causing exceptions after ending the test, is still reported correctly _after_ the initially deferred end has finished.

A new "promise-plan" test has been added for the scenario outlined in #240.

---

Some tests have now have extra newlines in their TAP output. This is due to https://github.com/tapjs/node-tap/blob/d5e11d0f660ac0a38b486adfb505b28a02e51fd3/lib/test.js#L543:L544 which may run when an end is deferred. I decided not to put in an extra guard since the newlines are probably harmless. I also believe this same condition may occur when using asynchronous `afterEach` callbacks, so it's not really a new issue.
