### PR TITLE
Show only master branch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A <abbr title="Test Anything Protocol">TAP</abbr> test framework for
 Node.js.
 
-[![Build Status](https://travis-ci.org/tapjs/node-tap.svg)](https://travis-ci.org/tapjs/node-tap/) [![Build Status](https://ci.appveyor.com/api/projects/status/913p1ypf21gf4leu?svg=true)](https://ci.appveyor.com/project/isaacs/node-tap) [![Coverage Status](https://coveralls.io/repos/tapjs/node-tap/badge.svg?branch=master&service=github)](https://coveralls.io/github/tapjs/node-tap?branch=master)
+[![Build Status](https://travis-ci.org/tapjs/node-tap.svg?branch=master)](https://travis-ci.org/tapjs/node-tap) [![Build Status](https://ci.appveyor.com/api/projects/status/913p1ypf21gf4leu?svg=true)](https://ci.appveyor.com/project/isaacs/node-tap) [![Coverage Status](https://coveralls.io/repos/tapjs/node-tap/badge.svg?branch=master&service=github)](https://coveralls.io/github/tapjs/node-tap?branch=master)
 
 It includes a command line test runner for consuming TAP-generating
 test scripts, and a JavaScript framework for writing such scripts.


### PR DESCRIPTION
The badge shown on README is updating for every build on the repo rather than only the master branch. This means if a pull request fails, it will shown as if this repo is failing to build while it is not.
