### PR TITLE
Update nyc to v6.4.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.0.0",
     "isexe": "^1.0.0",
     "js-yaml": "^3.3.1",
-    "nyc": "^5.5.0",
+    "nyc": "^6.4.0",
     "only-shallow": "^1.0.2",
     "opener": "^1.4.1",
     "readable-stream": "^2.0.2",


### PR DESCRIPTION
`nyc` v6.x added some useful new features, including the ability to include specific file extensions (such as `.jsx`). This updates `tap` to the latest version of `nyc` so that we can take advantage of them!

I'm using this modified version of `tap` in my application and it's working as expected.
