### PR TITLE
make coverage piping error non-fatal

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -391,7 +391,7 @@ function pipeToCoverageService (service, options, child) {
     if (signal) {
       process.kill(process.pid, signal)
     } else if (code) {
-      process.exit(code)
+      console.log('Error piping coverage to ' + service.name)
     } else {
       console.log('Successfully piped to ' + service.name)
     }


### PR DESCRIPTION
If the coveralls.io API returns an error, such as an unrecognized token
or some temporary service glitch, the test run should probably not end
in a failure if it was otherwise successful at running all the tests.

Originally reported as bcoe/nyc#241 before I looked at the code.

Example of the bad behaviour: https://travis-ci.org/strongloop/node-foreman/jobs/126987733
