### PR TITLE
Added types definition for TypeScript (picking up #238)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "description": "A Test-Anything-Protocol library",
   "homepage": "http://node-tap.org/",
+  "typings": "./tap.d.ts",
   "bin": {
     "tap": "bin/run.js"
   },

--- a/tap.d.ts
+++ b/tap.d.ts
@@ -1,0 +1,39 @@
+// tap.d.ts
+
+declare module Test {
+
+  class Deferred {
+    resolve();
+    reject();
+  }
+
+  class test {
+    constructor(options?: any);
+    tearDown();
+    setTimeout(n: number);
+    endAll();
+    threw(er: Error, extra: Error, proxy: any);
+    pragma(set: any);
+    plan(n: number, comment?: string);
+    test(name: string, extra: Error, cb: () => void, deferred: Deferred);
+    loop(self: test, arr: test[], cb: () => void, i: number);
+    next(er: Error);
+    current();
+    stdin(name: string, extra: any, deferred: Deferred);
+    spawn(cmd: string, args: string, options: any, name: string, extra: any, deferred: Deferred);
+    done(implicit: boolean);
+    autoend();
+    printResult(ok: boolean, message: string, extra: any);
+    writeDiags(extra: any);
+    passing();
+    pass(message: string, extra: any);
+    fail(message: string, extra: any);
+    addAssert(name: string, length: number, fn: () => void);
+    comment();
+    push(chunk: any, encoding?: string);
+    bailout(message: string);
+    beforeEach(fn: () => void);
+    afterEach(fn: () => void);
+  }
+  
+}

--- a/tap.d.ts
+++ b/tap.d.ts
@@ -22,16 +22,13 @@ declare class Test {
   stdin(name: string, extra?: Options.Bag): Promise
   spawn(cmd: string, args: string, options?: Options.Bag, name?: string, extra?: Options.Spawn): Promise
   done()
-  autoend()
-  printResult(ok: boolean, message: string, extra: Options.Assert)
-  writeDiags(extra: Options.Bag)
   passing()
   pass(message?: string, extra?: Options.Assert)
   fail(message?: string, extra?: Options.Assert)
   addAssert(name: string, length: number, fn: (...args) => boolean)
   comment(message: string, ...args)
   bailout(message?: string)
-  beforeEach(fn: (cb: () => any) => void)
+  beforeEach(fn: (cb: () => any) => Promise | void)
   afterEach(fn: (cb: () => any) => Promise | void)
 
   // Assertions

--- a/tap.d.ts
+++ b/tap.d.ts
@@ -10,26 +10,26 @@ declare interface Tap extends Test {
 
 declare class Test {
   constructor (options?: Options.Test)
-  tearDown(fn: (any) => any)
-  setTimeout(n: number)
-  endAll()
-  threw(er: Error, extra?: Error, proxy?: Test)
-  pragma(set: Options.Pragma)
-  plan(n: number, comment?: string)
+  tearDown(fn:(a:any) => any):void
+  setTimeout(n: number):void
+  endAll():void
+  threw(er: Error, extra?: Error, proxy?: Test):void
+  pragma(set: Options.Pragma):void
+  plan(n: number, comment?: string):void
   test(name: string, extra?: Options.Test, cb?: (t: Test) => Promise | void): Promise
   test(name: string, cb?: (t: Test) => Promise | void): Promise
-  current()
+  current(): Test
   stdin(name: string, extra?: Options.Bag): Promise
   spawn(cmd: string, args: string, options?: Options.Bag, name?: string, extra?: Options.Spawn): Promise
-  done()
-  passing()
-  pass(message?: string, extra?: Options.Assert)
-  fail(message?: string, extra?: Options.Assert)
-  addAssert(name: string, length: number, fn: (...args) => boolean)
-  comment(message: string, ...args)
-  bailout(message?: string)
-  beforeEach(fn: (cb: () => any) => Promise | void)
-  afterEach(fn: (cb: () => any) => Promise | void)
+  done():void
+  passing():boolean
+  pass(message?: string, extra?: Options.Assert):boolean
+  fail(message?: string, extra?: Options.Assert):boolean
+  addAssert(name: string, length: number, fn: (...args:any[]) => boolean): boolean
+  comment(message: string, ...args:any[]):void
+  bailout(message?: string):void
+  beforeEach(fn: (cb: () => any) => Promise | void):void
+  afterEach(fn: (cb: () => any) => Promise | void):void
 
   // Assertions
   ok: Assertions.Basic
@@ -165,10 +165,10 @@ declare namespace Assertions {
     (obj: any, message?: string, extra?: Options.Assert) => boolean
 
   export type Throws =
-    (fn?: (any) => any, expectedError?: Error, message?: string, extra?: Options.Assert) => boolean
+    (fn?: (a:any) => any, expectedError?: Error, message?: string, extra?: Options.Assert) => boolean
 
   export type DoesNotThrow =
-    (fn?: (any) => any, message?: string, extra?: Options.Assert) => boolean
+    (fn?: (a:any) => any, message?: string, extra?: Options.Assert) => boolean
 
   export type Equal =
     (found: any, wanted: any, message?: string, extra?: Options.Assert) => boolean
@@ -180,7 +180,7 @@ declare namespace Assertions {
     (found: any, pattern: any, message?: string, extra?: Options.Assert) => boolean
 
   export type Type =
-    (found: any, type: string | ((any) => any), message?: string, extra?: Options.Assert) => boolean
+    (found: any, type: string | ((a:any) => any), message?: string, extra?: Options.Assert) => boolean
 }
 
 // Super minimal description of returned Promise (which are really Bluebird promises)
@@ -191,8 +191,8 @@ declare interface Promise {
 }
 
 declare interface Mocha {
-  it: (name?: string, fn?: (any) => any) => void
-  describe: (name?: string, fn?: (any) => any) => void
+  it: (name?: string, fn?: (a:any) => any) => void
+  describe: (name?: string, fn?: (a:any) => any) => void
   global: () => void
 }
 
@@ -203,3 +203,4 @@ declare interface TestConstructor {
 }
 
 export = tap;
+

--- a/tap.d.ts
+++ b/tap.d.ts
@@ -1,39 +1,208 @@
 // tap.d.ts
 
-declare module Test {
+declare var tap: Tap;
 
-  class Deferred {
-    resolve();
-    reject();
-  }
-
-  class test {
-    constructor(options?: any);
-    tearDown();
-    setTimeout(n: number);
-    endAll();
-    threw(er: Error, extra: Error, proxy: any);
-    pragma(set: any);
-    plan(n: number, comment?: string);
-    test(name: string, extra: Error, cb: () => void, deferred: Deferred);
-    loop(self: test, arr: test[], cb: () => void, i: number);
-    next(er: Error);
-    current();
-    stdin(name: string, extra: any, deferred: Deferred);
-    spawn(cmd: string, args: string, options: any, name: string, extra: any, deferred: Deferred);
-    done(implicit: boolean);
-    autoend();
-    printResult(ok: boolean, message: string, extra: any);
-    writeDiags(extra: any);
-    passing();
-    pass(message: string, extra: any);
-    fail(message: string, extra: any);
-    addAssert(name: string, length: number, fn: () => void);
-    comment();
-    push(chunk: any, encoding?: string);
-    bailout(message: string);
-    beforeEach(fn: () => void);
-    afterEach(fn: () => void);
-  }
-  
+declare interface Tap extends Test {
+  Test: TestConstructor
+  mocha: Mocha
+  mochaGlobals: () => void
 }
+
+declare class Test {
+  constructor (options?: Options.Test)
+  tearDown(fn: (any) => any)
+  setTimeout(n: number)
+  endAll()
+  threw(er: Error, extra?: Error, proxy?: Test)
+  pragma(set: Options.Pragma)
+  plan(n: number, comment?: string)
+  test(name: string, extra?: Options.Test, cb?: (t: Test) => Promise | void): Promise
+  test(name: string, cb?: (t: Test) => Promise | void): Promise
+  current()
+  stdin(name: string, extra?: Options.Bag): Promise
+  spawn(cmd: string, args: string, options?: Options.Bag, name?: string, extra?: Options.Spawn): Promise
+  done()
+  autoend()
+  printResult(ok: boolean, message: string, extra: Options.Assert)
+  writeDiags(extra: Options.Bag)
+  passing()
+  pass(message?: string, extra?: Options.Assert)
+  fail(message?: string, extra?: Options.Assert)
+  addAssert(name: string, length: number, fn: (...args) => boolean)
+  comment(message: string, ...args)
+  bailout(message?: string)
+  beforeEach(fn: (cb: () => any) => void)
+  afterEach(fn: (cb: () => any) => Promise | void)
+
+  // Assertions
+  ok: Assertions.Basic
+  true: Assertions.Basic
+  assert: Assertions.Basic
+
+  notOk: Assertions.Basic
+  false: Assertions.Basic
+  assertNot: Assertions.Basic
+
+  error: Assertions.Basic
+  ifErr: Assertions.Basic
+  ifError: Assertions.Basic
+
+  throws: Assertions.Throws
+  throw: Assertions.Throws
+
+  doesNotThrow: Assertions.DoesNotThrow
+  notThrow: Assertions.DoesNotThrow
+
+  equal: Assertions.Equal
+  equals: Assertions.Equal
+  isEqual: Assertions.Equal
+  is: Assertions.Equal
+  strictEqual: Assertions.Equal
+  strictEquals: Assertions.Equal
+  strictIs: Assertions.Equal
+  isStrict: Assertions.Equal
+  isStrictly: Assertions.Equal
+
+  notEqual: Assertions.NotEqual
+  notEquals: Assertions.NotEqual
+  inequal: Assertions.NotEqual
+  notStrictEqual: Assertions.NotEqual
+  notStrictEquals: Assertions.NotEqual
+  isNotEqual: Assertions.NotEqual
+  isNot: Assertions.NotEqual
+  doesNotEqual: Assertions.NotEqual
+  isInequal: Assertions.NotEqual
+
+  same: Assertions.Equal
+  equivalent: Assertions.Equal
+  looseEqual: Assertions.Equal
+  looseEquals: Assertions.Equal
+  deepEqual: Assertions.Equal
+  deepEquals: Assertions.Equal
+  isLoose: Assertions.Equal
+  looseIs: Assertions.Equal
+
+  notSame: Assertions.NotEqual
+  inequivalent: Assertions.NotEqual
+  looseInequal: Assertions.NotEqual
+  notDeep: Assertions.NotEqual
+  deepInequal: Assertions.NotEqual
+  notLoose: Assertions.NotEqual
+  looseNot: Assertions.NotEqual
+
+  strictSame: Assertions.Equal
+  strictEquivalent: Assertions.Equal
+  strictDeepEqual: Assertions.Equal
+  sameStrict: Assertions.Equal
+  deepIs: Assertions.Equal
+  isDeeply: Assertions.Equal
+  isDeep: Assertions.Equal
+  strictDeepEquals: Assertions.Equal
+
+  strictNotSame: Assertions.NotEqual
+  strictInequivalent: Assertions.NotEqual
+  strictDeepInequal: Assertions.NotEqual
+  notSameStrict: Assertions.NotEqual
+  deepNot: Assertions.NotEqual
+  notDeeply: Assertions.NotEqual
+  strictDeepInequals: Assertions.NotEqual
+  notStrictSame: Assertions.NotEqual
+
+  match: Assertions.Match
+  has: Assertions.Match
+  hasFields: Assertions.Match
+  matches: Assertions.Match
+  similar: Assertions.Match
+  like: Assertions.Match
+  isLike: Assertions.Match
+  includes: Assertions.Match
+  include: Assertions.Match
+  contains: Assertions.Match
+
+  notMatch: Assertions.Match
+  dissimilar: Assertions.Match
+  unsimilar: Assertions.Match
+  notSimilar: Assertions.Match
+  unlike: Assertions.Match
+  isUnlike: Assertions.Match
+  notLike: Assertions.Match
+  isNotLike: Assertions.Match
+  doesNotHave: Assertions.Match
+  isNotSimilar: Assertions.Match
+  isDissimilar: Assertions.Match
+
+  type: Assertions.Type
+  isa: Assertions.Type
+  isA: Assertions.Type
+}
+
+declare namespace Options {
+  export interface Bag {
+    [propName: string]: any
+  }
+
+  export interface Pragma {
+    [propName: string]: boolean
+  }
+
+  export interface Assert extends Bag {
+    todo?: boolean | string,
+    skip?: boolean | string
+  }
+
+  export interface Spawn extends Assert {
+    bail?: boolean,
+    timeout?: number
+  }
+
+  export interface Test extends Assert {
+    name?: string,
+    timeout?: number,
+    bail?: boolean,
+    autoend?: boolean
+  }
+}
+
+declare namespace Assertions {
+  export type Basic =
+    (obj: any, message?: string, extra?: Options.Assert) => boolean
+
+  export type Throws =
+    (fn?: (any) => any, expectedError?: Error, message?: string, extra?: Options.Assert) => boolean
+
+  export type DoesNotThrow =
+    (fn?: (any) => any, message?: string, extra?: Options.Assert) => boolean
+
+  export type Equal =
+    (found: any, wanted: any, message?: string, extra?: Options.Assert) => boolean
+
+  export type NotEqual =
+    (found: any, notWanted: any, message?: string, extra?: Options.Assert) => boolean
+
+  export type Match =
+    (found: any, pattern: any, message?: string, extra?: Options.Assert) => boolean
+
+  export type Type =
+    (found: any, type: string | ((any) => any), message?: string, extra?: Options.Assert) => boolean
+}
+
+// Super minimal description of returned Promise (which are really Bluebird promises)
+declare interface Promise {
+  [propName: string] : any
+  then(fn: (t: Test) => any): Promise
+  catch(fn: (err: Error) => any): Promise
+}
+
+declare interface Mocha {
+  it: (name?: string, fn?: (any) => any) => void
+  describe: (name?: string, fn?: (any) => any) => void
+  global: () => void
+}
+
+// Little hack to simulate the Test class on the tap export
+declare interface TestConstructor {
+  new(options?: Options.Test): Test
+  prototype: Test
+}
+
+export = tap;


### PR DESCRIPTION
I've picked up on @brennanMKE's work from #238 and attempted to address the points of @isaacs's feedback.
- No internal implementation details are exported
- All assertions and synonyms mentioned in the public documentation are included
- parameter types have been tightened down where possible
- Exported description now closely mirrors the actual exported object

Additionally, I've added a `typings` field to the package.json, which should make tap work "out of the box" with versions of Typescript >= 1.6. It's in a separate commit in case that weirds anyone out. (See: http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html for reference)

Have attempted to be thorough and have referenced both the documentation and the source. Seems to work well from my own usage. Let me know if you see any problems and I'm happy to bang on it a little more. A few things I know of that are lacking / loose-endy:
1. There are some generated iterations of assertion synonyms not mentioned in the API docs that I didn't include in the type definitions. It wouldn't be a big deal to add them if you'd like
2. I've included only a super-minimal description of the promises returned from the `test`, `spawn` and `stdin` methods. What's actually returned is a Bluebird promise. Wasn't sure the right way to proceed with this.
3. I've made no attempt to document the inherited properties of readable-streams.

Cheers!
