### PR TITLE
Correct a typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-- Check the [issues](https://github.com/taprc/node-tap/issues) to see
+- Check the [issues](https://github.com/tapjs/node-tap/issues) to see
   stuff that is likely to be accepted.
 - Every patch should have a new test that fails without the patch and
   passes with the patch.

--- a/test/test/nesting.tap
+++ b/test/test/nesting.tap
@@ -36,7 +36,7 @@ not ok 3 - this fails
     ok 1 - second timeout
     not ok 2 - first timeout
       ---
-      {"at":{"column":7,"file":"test/test/nesting.js","line":33,"method":"_onTimeout"},"foo":"blz","source":"t.ok(false, 'first timeout', { foo: 'blz' })\n"}
+      {"at":{"column":7,"file":"test/test/nesting.js","line":33,"method":"_onTimeout","type":"Timeout"},"foo":"blz","source":"t.ok(false, 'first timeout', { foo: 'blz' })\n"}
       ...
     # failed 1 of 2 tests
 not ok 4 - async kid ___/# time=[0-9.]+(ms)?/~~~

--- a/test/test/spawn.tap
+++ b/test/test/spawn.tap
@@ -37,7 +37,7 @@ TAP version 13
         ok 1 - second timeout
         not ok 2 - first timeout
           ---
-          {"at":{"column":7,"file":"test/test/spawn.js","line":41,"method":"_onTimeout"},"foo":"blz","source":"t.ok(false, 'first timeout', { foo: 'blz' })\n"}
+          {"at":{"column":7,"file":"test/test/spawn.js","line":41,"method":"_onTimeout","type":"Timeout"},"foo":"blz","source":"t.ok(false, 'first timeout', { foo: 'blz' })\n"}
           ...
         # failed 1 of 2 tests
     not ok 4 - async kid ___/# time=[0-9.]+(ms)?/~~~
@@ -91,7 +91,7 @@ not ok 4 - this fails
     ok 1 - second timeout
     not ok 2 - first timeout
       ---
-      {"at":{"column":7,"file":"test/test/spawn.js","line":41,"method":"_onTimeout"},"foo":"blz","source":"t.ok(false, 'first timeout', { foo: 'blz' })\n"}
+      {"at":{"column":7,"file":"test/test/spawn.js","line":41,"method":"_onTimeout","type":"Timeout"},"foo":"blz","source":"t.ok(false, 'first timeout', { foo: 'blz' })\n"}
       ...
     # failed 1 of 2 tests
 not ok 5 - async kid ___/# time=[0-9.]+(ms)?/~~~


### PR DESCRIPTION
Fix a small typo. The previous link referenced a nonexistent user/group.

NOTE: I ran `npm run regen-fixtures` as directed. I tried to figure out where this change came from by checking out old releases (back to v5.5.0), deleting node_moduels, `npm i`, and regening fixtures. Unfortunately I only saw larger differences in the tap output than what appears below.
