### PR TITLE
Add CLI flag to avoid opening a browser window

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -141,6 +141,7 @@ function parseArgs (args) {
   var defaultCoverage = options.pipeToService
 
   options.coverageReport = null
+  options.openBrowser = true
 
   for (i = 0; i < args.length; i++) {
     var arg = args[i]
@@ -213,6 +214,10 @@ function parseArgs (args) {
           options.coverageReport = 'lcov'
         }
         defaultCoverage = true
+        continue
+
+      case '--no-browser':
+        options.openBrowser = false
         continue
 
       case '--no-coverage-report':
@@ -431,7 +436,7 @@ function runCoverageReportOnly (options, code, signal) {
   } else {
     // otherwise just run the reporter
     child = fg(node, args)
-    if (options.coverageReport === 'lcov') {
+    if (options.coverageReport === 'lcov' && options.openBrowser) {
       child.on('exit', function () {
         opener('coverage/lcov-report/index.html')
       })


### PR DESCRIPTION
I've added a new command line flag to prevent tap from opening a new browser window after generating an HTML report.

I wanted to use nodemon with my project's test-coverage npm script, but the auto-open behavior ended up spawning a lot of unused browser tabs. Hopefully this will address that workflow issue should anyone else run into a similar hitch.

I couldn't find anywhere in the existing tests for command line options. Please let me know if I missed something obvious or if I should take a crack at creating a new test.
