### PR TITLE
Fixing endless loop for coverage if -- is used when run in node_modules

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -173,6 +173,17 @@ function parseArgs (args, defaults) {
   var defaultCoverage = options.pipeToService
   var dumpConfig = false
 
+  if (args.indexOf('--__coverage__') !== -1) {
+    // NYC will not wrap a module in node_modules.
+    // So, we need to tell the child proc when it's been added.
+    global.__coverage__ = global.__coverage__ || {}
+
+    // Make sure that --__coverage__ is newer processed as argument.
+    args = args.filter(function (arg) {
+      return arg !== '--__coverage__'
+    })
+  }
+
   for (i = 0; i < args.length; i++) {
     var arg = args[i]
     if (arg.charAt(0) !== '-' || arg === '-') {
@@ -235,12 +246,6 @@ function parseArgs (args, defaults) {
       case '--version':
         console.log(require('../package.json').version)
         return null
-
-      case '--__coverage__':
-        // NYC will not wrap a module in node_modules.
-        // So, we need to tell the child proc when it's been added.
-        global.__coverage__ = global.__coverage__ || {}
-        continue
 
       case '--coverage-report':
         options.coverageReport = val || args[++i]


### PR DESCRIPTION
My tests were run in a constellation where [`nyc` didn't set the `global.__coverage__`](https://github.com/tapjs/node-tap/blob/e49616d1e8c7f726e1c6834bbec81c19509f72fa/bin/run.js#L240) property and I used `--cov -- mytest.js` as command line options.

In this constellation node-tap ran into an **endless loop** because all arguments after `--` are treated as [files](https://github.com/tapjs/node-tap/blob/e49616d1e8c7f726e1c6834bbec81c19509f72fa/bin/run.js#L366), including `--__coverage__`.

This PR fixes that problem by testing the arguments before any other parsing for `__coverage__`.
