### PR TITLE
Fix tiny typo in asserts/index.md

### DIFF
--- a/asserts/index.md
+++ b/asserts/index.md
@@ -55,7 +55,7 @@ provided, then also verify that the thrown error matches the expected
 error.
 
 If the expected error is an object, then it's matched against the
-thrown error using `t.match(er, expectedEror)`.  If it's a function,
+thrown error using `t.match(er, expectedError)`.  If it's a function,
 then the error is asserted to be a member of that class.
 
 If the function has a name, and the message is not provided, then the


### PR DESCRIPTION
`expectedEror` → `expectedError`
