### PR TITLE
Add -J to automatically calculate cores

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -13,6 +13,7 @@ var osHomedir = require('os-homedir')
 var yaml = require('js-yaml')
 var path = require('path')
 var exists = require('fs-exists-cached').sync
+var os = require('os');
 
 var coverageServiceTest = process.env.COVERAGE_SERVICE_TEST === 'true'
 
@@ -158,6 +159,7 @@ function parseArgs (args, defaults) {
 
   var singleOpts = {
     j: 'jobs',
+    J: 'Jobs',
     R: 'reporter',
     t: 'timeout',
     s: 'save'
@@ -237,6 +239,11 @@ function parseArgs (args, defaults) {
 
       case '--jobs':
         val = val || args[++i]
+        options.jobs = +val
+        continue
+
+      case '--Jobs':
+        val = os.cpus().length;
         options.jobs = +val
         continue
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -23,6 +23,12 @@ Options:
                               cannot be reported, and older TAP
                               parsers may get upset.
 
+  -J --Jobs                   Run test files in parallel (auto calculated)
+                              Note that this causes tests to be run in
+                              "buffered" mode, so line-by-line results
+                              cannot be reported, and older TAP
+                              parsers may get upset.
+
   -c --color                  Use colors (Default for TTY)
 
   -C --no-color               Do not use colors (Default for non-TTY)


### PR DESCRIPTION
This PR allows you to pass in `-J` which will automatically calculate
the number of cores using `os.cpus().length`

Fixes: https://github.com/tapjs/node-tap/issues/342