### PR TITLE
Copy Error message to extra object fixes #366

### DIFF
--- a/lib/extra-from-error.js
+++ b/lib/extra-from-error.js
@@ -20,8 +20,7 @@ module.exports = function (er, extra, options) {
     addName = false
   }
 
-  extra.message = message
-
+  er.message = ''
   var st = er.stack
   if (st) {
     st = st.split('\n')
@@ -29,6 +28,7 @@ module.exports = function (er, extra, options) {
     extra.at = stack.parseLine(st[1])
     extra.stack = stack.clean(st)
   }
+  er.message = message
 
   if (er.name && er.name !== 'Error')
     extra.type = er.name
@@ -42,6 +42,8 @@ module.exports = function (er, extra, options) {
       return
     extra[k] = er[k]
   })
+
+  if(!extra.message) extra.message = message
 
   return extra
 }

--- a/lib/extra-from-error.js
+++ b/lib/extra-from-error.js
@@ -20,7 +20,8 @@ module.exports = function (er, extra, options) {
     addName = false
   }
 
-  er.message = ''
+  extra.message = message
+
   var st = er.stack
   if (st) {
     st = st.split('\n')
@@ -28,7 +29,6 @@ module.exports = function (er, extra, options) {
     extra.at = stack.parseLine(st[1])
     extra.stack = stack.clean(st)
   }
-  er.message = message
 
   if (er.name && er.name !== 'Error')
     extra.type = er.name


### PR DESCRIPTION
Since `k` can not be a 'message' it's save to assign message just after the `er.stack.split` block.