### PR TITLE
Add NaN support for strictSame()

### DIFF
--- a/lib/asserts.js
+++ b/lib/asserts.js
@@ -1,5 +1,5 @@
 var synonyms = require('./synonyms.js')
-var deeper = require('deeper') // strict
+var deepEqual = require('lodash.isequal') // strict
 var shallower = require('only-shallow') // in touch with its feelings
 var tmatch = require('tmatch') // ok with partial estimates
 var extraFromError = require('./extra-from-error.js')
@@ -100,14 +100,14 @@ function decorate (t) {
     m = m || 'should be equivalent strictly'
     e.found = f
     e.wanted = w
-    return this.ok(deeper(f, w), m, e)
+    return this.ok(deepEqual(f, w), m, e)
   })
 
   t.addAssert('strictNotSame', 2, function (f, w, m, e) {
     m = m || 'should be equivalent strictly'
     e.found = f
     e.doNotWant = w
-    return this.notOk(deeper(f, w), m, e)
+    return this.notOk(deepEqual(f, w), m, e)
   })
 
   t.addAssert('match', 2, function (f, w, m, e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -278,11 +278,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "deeper": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
-      "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g="
-    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -783,6 +778,12 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "log-driver": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clean-yaml-object": "^0.1.0",
     "color-support": "^1.1.0",
     "coveralls": "^2.11.2",
-    "deeper": "^2.1.0",
     "foreground-child": "^1.3.3",
     "fs-exists-cached": "^1.0.0",
     "function-loop": "^1.0.1",
@@ -58,6 +57,7 @@
     "postpublish": "git push origin --all; git push origin --tags"
   },
   "devDependencies": {
+    "lodash.isequal": "^4.5.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.4",
     "standard": "^7.1.0",

--- a/test/asserts.js
+++ b/test/asserts.js
@@ -144,6 +144,7 @@ test('strictSame is deep strict equality', function (t) {
   t.not_ok(tt.strict_same([1, 2], ['1', '2']))
   t.notOk(tt.strict_same([1, '2'], ['1', 2]))
   t.strictSame([1, 2], [1, 2])
+  t.strictSame({ nan: { nan: NaN } }, { nan: { nan: NaN } })
   t.end()
 })
 


### PR DESCRIPTION
`deeper` support seems to be discontinued, last commit is of Aug 31, 2015.
Also `lodash.isequal` handles `NaN` properly but `deeper` doesn't, which is the main reason of this PR.