### PR TITLE
WIP – TAP_ONLY, --only, {only: true} and "only" warning

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -154,6 +154,7 @@ function parseArgs (args, defaults) {
     C: 'no-color',
     T: 'no-timeout',
     J: 'jobs-auto',
+    O: 'only',
     h: 'help',
     '?': 'help',
     v: 'version'

--- a/bin/run.js
+++ b/bin/run.js
@@ -375,6 +375,10 @@ function parseArgs (args, defaults) {
         options.bail = false
         continue
 
+      case '--only':
+        options.only = true
+        continue
+
       case '--':
         options.files = options.files.concat(args.slice(i + 1))
         i = args.length
@@ -576,6 +580,9 @@ function setupTapEnv (options) {
 
   if (options.bail)
     process.env.TAP_BAIL = '1'
+
+  if (options.only)
+    process.env.TAP_ONLY = '1'
 }
 
 function globFiles (files) {

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -37,6 +37,8 @@ Options:
 
   -B --no-bail                Do not bail out on first failure (Default)
 
+  -O --only                   Only run tests with {only: true} option
+
   -R<type> --reporter=<type>  Use the specified reporter.  Defaults to
                               'classic' when colors are in use, or 'tap'
                               when colors are disabled.

--- a/lib/base.js
+++ b/lib/base.js
@@ -42,6 +42,7 @@ function Base (options) {
   this.jobs = +ownOrEnv(options, 'jobs', 'TAP_JOBS') || 0
   this.skip = ownOr(options, 'skip', false)
   this.todo = ownOr(options, 'todo', false)
+  this.only = ownOr(options, 'only', false)
   this.setupParser(options)
   this.finished = false
   this.output = ''
@@ -212,6 +213,7 @@ Base.prototype.inspect = function () {
     output: this.output,
     skip: this.skip,
     todo: this.todo,
+    only: this.only,
     results: this.results,
     options: [
       'autoend',
@@ -226,7 +228,8 @@ Base.prototype.inspect = function () {
       'timeout',
       'at',
       'skip',
-      'todo'
+      'todo',
+      'only'
     ].reduce(function (set, k) {
       if (this.options[k] !== undefined)
         set[k] = this.options[k]

--- a/lib/clean-yaml-object.js
+++ b/lib/clean-yaml-object.js
@@ -59,6 +59,7 @@ function yamlFilter (propertyName, isRoot, source, target) {
   propertyName === 'indent' ||
   propertyName === 'skip' ||
   propertyName === 'bail' ||
+  propertyName === 'only' ||
   propertyName === 'diagnostic' ||
   propertyName === 'buffered' ||
   propertyName === 'parent' ||

--- a/lib/point.js
+++ b/lib/point.js
@@ -31,6 +31,8 @@ function tpMessage (message, extra) {
     message += ' # TODO'
     if (typeof extra.todo === 'string')
       message += ' ' + extra.todo
+  } else if (extra.only) {
+    message += ' # ONLY'
   } else if (extra.time)
     message += ' # time=' + extra.time + 'ms'
 

--- a/lib/tap.js
+++ b/lib/tap.js
@@ -118,6 +118,10 @@ if (process.env.TAP_DEBUG === '1' ||
     /\btap\b/.test(process.env.NODE_DEBUG || ''))
   opt.debug = true
 
+if (process.env.TAP_ONLY === '1') {
+  opt.only = true
+}
+
 var tap = new TAP(opt)
 module.exports = tap
 tap.mocha = require('./mocha.js')

--- a/lib/test.js
+++ b/lib/test.js
@@ -110,7 +110,11 @@ Test.prototype.spawn = function spawn (cmd, args, options, name) {
 }
 
 Test.prototype.sub = function (Class, extra, caller) {
-  if (extra && (extra.todo || extra.skip)) {
+  if (extra.only && !this.only) {
+    process.stderr.write('# Warning: "' + extra.name + '" has {todo: true} set but all tests are run\n')
+  }
+
+  if (extra && (extra.todo || extra.skip || (this.only && !extra.only))) {
     this.pass(extra.name, extra)
     return Promise.resolve(this)
   }

--- a/lib/test.js
+++ b/lib/test.js
@@ -111,7 +111,7 @@ Test.prototype.spawn = function spawn (cmd, args, options, name) {
 
 Test.prototype.sub = function (Class, extra, caller) {
   if (extra.only && !this.only) {
-    process.stderr.write('# Warning: "' + extra.name + '" has {todo: true} set but all tests are run\n')
+    process.stderr.write('# Warning: "' + extra.name + '" has {only: true} set but all tests are run\n')
   }
 
   if (extra && (extra.todo || extra.skip || (this.only && !extra.only))) {

--- a/test/fixtures/only.js
+++ b/test/fixtures/only.js
@@ -5,7 +5,7 @@ test('normal', function (t) {
   t.end()
 })
 
-test('only', {todo: true}, function (t) {
+test('only', {only: true}, function (t) {
   t.pass('ok')
   t.end()
 })

--- a/test/fixtures/only.js
+++ b/test/fixtures/only.js
@@ -5,7 +5,7 @@ test('normal', function (t) {
   t.end()
 })
 
-test('only', {skip: true}, function (t) {
+test('only', {todo: true}, function (t) {
   t.pass('ok')
   t.end()
 })

--- a/test/fixtures/only.js
+++ b/test/fixtures/only.js
@@ -1,0 +1,11 @@
+var test = require('../..').test
+
+test('normal', function (t) {
+  t.pass('will log an error when run without TAP_ONLY=1')
+  t.end()
+})
+
+test('only', {skip: true}, function (t) {
+  t.pass('ok')
+  t.end()
+})

--- a/test/fixtures/only.js
+++ b/test/fixtures/only.js
@@ -1,6 +1,25 @@
 var test = require('../..').test
 
-test('only', {only: true}, function (t) {
-  t.pass('will log an error when run without TAP_ONLY=1')
+test('root test without {only: true}', function (t) {
+  t.pass('test will not run without --only')
   t.end()
+})
+
+test('root test with {only: true}', {only: true}, function (t) {
+  t.pass('test will log an error when run without --only')
+  t.end()
+})
+
+test('group', function (group) {
+  group.test('subtest without {only: true}', function (t) {
+    t.pass('subtest will not run without --only')
+    t.end()
+  })
+
+  group.test('subtest with {only: true}', {only: true}, function (t) {
+    t.pass('test will log an error when run without --only')
+    t.end()
+  })
+
+  group.end()
 })

--- a/test/fixtures/only.js
+++ b/test/fixtures/only.js
@@ -1,11 +1,6 @@
 var test = require('../..').test
 
-test('normal', function (t) {
-  t.pass('will log an error when run without TAP_ONLY=1')
-  t.end()
-})
-
 test('only', {only: true}, function (t) {
-  t.pass('ok')
+  t.pass('will log an error when run without TAP_ONLY=1')
   t.end()
 })

--- a/test/runner-only.js
+++ b/test/runner-only.js
@@ -1,0 +1,23 @@
+var t = require('../')
+var execFile = require('child_process').execFile
+var node = process.execPath
+var run = require.resolve('../bin/run.js')
+
+t.test('--only', function (t) {
+  var file = require.resolve('./fixtures/only.js')
+  var args = [
+    run,
+    '--only',
+    file
+  ]
+
+  execFile(node, args, function (err, stdout, stderr) {
+    if (err) {
+      throw err
+    }
+    t.equal(stderr, '')
+
+    t.match(stdout, /^ok 1 - .*[\\\/]only.js/m)
+    t.end()
+  })
+})

--- a/test/runner-only.js
+++ b/test/runner-only.js
@@ -3,7 +3,7 @@ var execFile = require('child_process').execFile
 var node = process.execPath
 var run = require.resolve('../bin/run.js')
 
-t.test('--only', function (t) {
+t.test('--only flag', function (t) {
   var file = require.resolve('./fixtures/only.js')
   var args = [
     run,
@@ -15,7 +15,27 @@ t.test('--only', function (t) {
     if (err) {
       throw err
     }
+
     t.equal(stderr, '')
+
+    t.match(stdout, /^ok 1 - .*[\\\/]only.js/m)
+    t.end()
+  })
+})
+
+t.test('{only: true} without --only flag', function (t) {
+  var file = require.resolve('./fixtures/only.js')
+  var args = [
+    run,
+    file
+  ]
+
+  execFile(node, args, function (err, stdout, stderr) {
+    if (err) {
+      throw err
+    }
+
+    t.equal(stderr.trim(), '# Warning: "only" has {only: true} set but all tests are run')
 
     t.match(stdout, /^ok 1 - .*[\\\/]only.js/m)
     t.end()

--- a/test/test/only--bail--buffer.tap
+++ b/test/test/only--bail--buffer.tap
@@ -1,0 +1,11 @@
+TAP version 13
+ok 1 - normal ___/# time=[0-9.]+(ms)?/~~~ {
+    ok 1 - will log an error when run without TAP_ONLY=1
+    1..1
+}
+
+ok 2 - only # SKIP
+1..2
+# skip: 1
+___/# time=[0-9.]+(ms)?/~~~
+

--- a/test/test/only--bail.tap
+++ b/test/test/only--bail.tap
@@ -1,0 +1,11 @@
+TAP version 13
+# Subtest: normal
+    ok 1 - will log an error when run without TAP_ONLY=1
+    1..1
+ok 1 - normal ___/# time=[0-9.]+(ms)?/~~~
+
+ok 2 - only # SKIP
+1..2
+# skip: 1
+___/# time=[0-9.]+(ms)?/~~~
+

--- a/test/test/only--buffer.tap
+++ b/test/test/only--buffer.tap
@@ -1,0 +1,11 @@
+TAP version 13
+ok 1 - normal ___/# time=[0-9.]+(ms)?/~~~ {
+    ok 1 - will log an error when run without TAP_ONLY=1
+    1..1
+}
+
+ok 2 - only # SKIP
+1..2
+# skip: 1
+___/# time=[0-9.]+(ms)?/~~~
+

--- a/test/test/only.js
+++ b/test/test/only.js
@@ -1,0 +1,11 @@
+var test = require('../..').test
+
+test('normal', function (t) {
+  t.pass('will log an error when run without TAP_ONLY=1')
+  t.end()
+})
+
+test('only', {skip: true}, function (t) {
+  t.pass('ok')
+  t.end()
+})

--- a/test/test/only.tap
+++ b/test/test/only.tap
@@ -1,0 +1,11 @@
+TAP version 13
+# Subtest: normal
+    ok 1 - will log an error when run without TAP_ONLY=1
+    1..1
+ok 1 - normal ___/# time=[0-9.]+(ms)?/~~~
+
+ok 2 - only # SKIP
+1..2
+# skip: 1
+___/# time=[0-9.]+(ms)?/~~~
+


### PR DESCRIPTION
# THIS IS WORK IN PROGRESS

writes warning to stderr if {only: true} but tap’s only option is not true

closes #187 

### Progress

- [x] make existing tests pass (rebase on master https://github.com/tapjs/node-tap/pull/374#issuecomment-309129473)
- [x] create test in `test/test/...` https://github.com/tapjs/node-tap/pull/374#issuecomment-308904189
- [x] create runner test https://github.com/tapjs/node-tap/pull/374#issuecomment-308904189
- [x] add --only to the set of configs that can be loaded from a .taprc file https://github.com/tapjs/node-tap/pull/374#issuecomment-308904189
- [x] update `usage.txt`