### PR TITLE
Fix Italian quote punctuation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just kidding.
 Most frameworks spend a lot of their documentation telling you why
 they're the greatest.  I'm not going to do that.
 
-### <i lang="it">tutti i gusti, sono gusti</i>
+### <i lang="it">tutti i gusti sono gusti</i>
 
 Software testing is a software and user experience design challenge
 that balances on the intersection of many conflicting demands.


### PR DESCRIPTION
In the sentence `tutti i gusti, sono gusti`, the subject `tutti i gusti` is separated from the verb `sono` with a comma. That's an error in Italian. Punctuation cannot be placed between the subject and the verb.