### PR TITLE
Add --require option to the cli

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -165,6 +165,7 @@ function parseArgs (args, defaults) {
   }
 
   var singleOpts = {
+    r: 'require',
     j: 'jobs',
     g: 'grep',
     R: 'reporter',
@@ -312,6 +313,12 @@ function parseArgs (args, defaults) {
         val = val || args[++i]
         if (val !== undefined)
           options.nodeArgs.push(val)
+        continue
+
+      case '--require':
+        val = val || args[++i]
+        if (val !== undefined)
+          options.nodeArgs.push('-r', val)
         continue
 
       case '--check-coverage':

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -17,6 +17,8 @@ Coverage is never enabled for stdin.
 
 Options:
 
+  -r<m> --require=<m>         Require module (e.g. babel-register)
+
   -j<n> --jobs=<n>            Run up to <n> test files in parallel
                               Note that this causes tests to be run in
                               "buffered" mode, so line-by-line results


### PR DESCRIPTION
Hey guys

I personally miss this feature very very much. I am having so much headache trying to figure out how to run awesome `node-tap` tests with e.g. babel

The reason to run src tests is to use flow in my case

Please tell me what I need to do to finish it ASAP and maybe include in v 11?