### PR TITLE
test: add emitsEvent() assertion

### DIFF
--- a/docs/asserts/index.md
+++ b/docs/asserts/index.md
@@ -88,6 +88,13 @@ not return a boolean to indicate its passing status.  Instead, it
 returns a Promise that resolves when it is completed.
 
 
+## t.emitsEvent (emitter, event_name, message, extra)
+
+Verifies that the emitter emits the event `event_name`.
+This comes with a default timeout of 2500 milliseconds. This can be
+changed by setting `extra.timeout`.
+
+
 ## t.throws(fn, [expectedError], message, extra)
 
 Expect the function to throw an error.  If an expected error is

--- a/lib/test.js
+++ b/lib/test.js
@@ -1348,6 +1348,56 @@ class Test extends Base {
         t.match(value, wanted, extra)
       }))
   }
+
+  emitsEvent (emitter, eventName, message, extra) {
+    this.currentAssert = Test.prototype.emitsEvent
+
+    if (message && typeof message === 'object')
+      extra = message, message = ''
+
+    if (!extra)
+      extra = {}
+
+    if (!message)
+      message = `expect emitter to emit event: "${eventName}"`
+
+    // have to do as a subtest, because events could be async
+    extra.at = stack.at(this.currentAssert)
+
+    const textra = {
+      buffered: true,
+      todo: extra.todo,
+      skip: extra.skip,
+      timeout: extra.timeout || 2500
+    }
+
+    if (!emitter || typeof emitter.on !== 'function') {
+      return this.test(message, extra, t => {
+        t.fail(message, extra)
+        t.end()
+      })
+    }
+
+    return this.test(message, textra, t => {
+      t.plan(1)
+      const handler = (arg) => {
+        emitter.removeListener(eventName, handler)
+        clearTimeout(timer)
+        t.pass(message)
+      }
+
+      const timer = setTimeout(() => {
+        emitter.removeListener(eventName, handler)
+        t.fail(message)
+      }, 2500)
+
+      t.on('end', () => {
+        emitter.removeListener(eventName, handler)
+      })
+
+      emitter.on(eventName, handler)
+    })
+  }
 }
 
 const endAllQueue = queue => {

--- a/tap-snapshots/test-test.js-TAP.test.js
+++ b/tap-snapshots/test-test.js-TAP.test.js
@@ -1822,6 +1822,124 @@ not ok 5 - fail: no promise # {time} {
 
 `
 
+exports[`test/test.js TAP assertions and weird stuff emitsEvent > emitsEvent 1`] = `
+TAP version 13
+ok 1 - expect emitter to emit event: "event_name" # {time} {
+    1..1
+    ok 1 - expect emitter to emit event: "event_name"
+}
+
+ok 2 - expect emitter to emit event: "event_name" # TODO
+not ok 3 - expect emitter to emit event: "another_event" # {time}
+  ---
+  timeout: 2500
+  ...
+{
+    1..1
+    not ok 1 - timeout!
+      ---
+      expired: 'expect emitter to emit event: "another_event"'
+      stack: |
+        {STACK}
+      test: 'expect emitter to emit event: "another_event"'
+      timeout: 2500
+      ...
+    
+    # failed 1 test
+}
+
+not ok 4 - fail: no emitter # {time}
+  ---
+  timeout: 2500
+  ...
+{
+    1..1
+    not ok 1 - timeout!
+      ---
+      expired: 'fail: no emitter'
+      stack: |
+        {STACK}
+      test: 'fail: no emitter'
+      timeout: 2500
+      ...
+    
+    # failed 1 test
+}
+
+not ok 5 - expect emitter to emit event: "immediate" # {time}
+  ---
+  timeout: 1
+  ...
+{
+    1..1
+    not ok 1 - timeout!
+      ---
+      expired: 'expect emitter to emit event: "immediate"'
+      stack: |
+        {STACK}
+      test: 'expect emitter to emit event: "immediate"'
+      timeout: 1
+      ...
+    
+    # failed 1 test
+}
+
+# Subtest: expect emitter to emit event: "event_name"
+    not ok 1 - expect emitter to emit event: "event_name"
+      ---
+      at:
+        line: #
+        column: #
+        file: test/test.js
+      source: |
+        tt.emitsEvent(null, 'event_name')
+      stack: |
+        {STACK}
+      ...
+    
+    1..1
+    # failed 1 test
+not ok 6 - expect emitter to emit event: "event_name" # {time}
+  ---
+  at:
+    line: #
+    column: #
+    file: test/test.js
+  source: |
+    tt.emitsEvent(null, 'event_name')
+  ...
+
+# Subtest: expect emitter to emit event: "event_name"
+    not ok 1 - expect emitter to emit event: "event_name"
+      ---
+      at:
+        line: #
+        column: #
+        file: test/test.js
+      source: |
+        tt.emitsEvent({}, 'event_name')
+      stack: |
+        {STACK}
+      ...
+    
+    1..1
+    # failed 1 test
+not ok 7 - expect emitter to emit event: "event_name" # {time}
+  ---
+  at:
+    line: #
+    column: #
+    file: test/test.js
+  source: |
+    tt.emitsEvent({}, 'event_name')
+  ...
+
+1..7
+# failed 5 of 7 tests
+# todo: 1
+
+`
+
 exports[`test/test.js TAP assertions and weird stuff test after end fails > test after end fails 1`] = `
 TAP version 13
 1..0

--- a/test/test.js
+++ b/test/test.js
@@ -455,6 +455,23 @@ t.test('assertions and weird stuff', t => {
       tt.end()
     },
 
+    emitsEvent: tt => {
+      const emitter = new EE()
+
+      setImmediate(() => {
+        emitter.emit('event_name', {})
+      })
+
+      tt.emitsEvent(emitter, 'event_name')
+      tt.emitsEvent(emitter, 'event_name', { todo: true })
+      tt.emitsEvent(emitter, 'another_event')
+      tt.emitsEvent(emitter, 'another_event', 'fail: no emitter')
+      tt.emitsEvent(emitter, 'immediate', { timeout: 1 }, 'fail: timeout')
+      tt.emitsEvent(null, 'event_name')
+      tt.emitsEvent({}, 'event_name')
+      tt.end()
+    },
+
     'test after end fails': tt => {
       tt.end()
       tt.pass('failing pass')


### PR DESCRIPTION
This adds a new assertion that verifies that an EventEmitter emits an
event. 

I've written this quite a few times now, so I figured someone else may find it useful.
I do think having the ability to match against the argument(s) being emitted would be a nice to have as well, but wasn't sure on the naming. Anyways, I wanted to go ahead and see if you were interested in this before implementing matching.