### PR TITLE
Update own-or-env to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "opener": "^1.4.1",
     "os-homedir": "^1.0.2",
     "own-or": "^1.0.0",
-    "own-or-env": "^1.0.0",
+    "own-or-env": "^1.0.1",
     "rimraf": "^2.6.2",
     "signal-exit": "^3.0.0",
     "source-map-support": "^0.4.18",


### PR DESCRIPTION
This PR updates the `own-or-env` dependency to version 1.0.1. This fixes an issue running `tap` when projects using `tap` have had their dependencies installed by a package manager that does not create a flat `node_modules` directory, e.g. [pnpm](http://pnpm.js.org/).