### PR TITLE
Fix typos in docs + update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,3 @@ Please consider signing [the neveragain.tech pledge](http://neveragain.tech/)
 - Prefer adding cases to an existing test rather than writing a new
   one from scratch.  For example, add a new test in `test/test/*.js`
   rather than create a new test that validates test output.
-- Docs should be changed on the `gh-pages` branch

--- a/docs/reporting/index.md
+++ b/docs/reporting/index.md
@@ -30,7 +30,7 @@ The following options are available:
 
 - doc
 
-    Output heirarchical HTML.
+    Output hierarchical HTML.
 
 - dot
 
@@ -59,7 +59,7 @@ The following options are available:
 
 - markdown
 
-    Heirarchical markdown output with a table of contents.
+    Hierarchical markdown output with a table of contents.
 
 - min
 
@@ -79,7 +79,7 @@ The following options are available:
 
 - spec
 
-    Output based on rspec, with heirarchical indentation and
+    Output based on rspec, with hierarchical indentation and
     unicode red and green checks and X's.
 
 - xunit


### PR DESCRIPTION
Hi

According the the Cambridge dictionary, [hierarchy has been misspelt](https://dictionary.cambridge.org/dictionary/english/hierarchy).

The contributing guide says that docs should be changed on the `gh-pages` branch but that doesn't longer seem to be the case. I took the liberty of updating the guide but happy to take out the offending commit if that's not correct :)