### PR TITLE
Browserifyable 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,11 @@ node_js:
   - 6
 notifications:
   email: false
+addons:
+  chrome: stable
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+script:
+  - npm run test
+  - npm run test-browser

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,11 +12,17 @@ function makeConf (config) {
 
   const browsers = process.env.BROWSER
     ? [process.env.BROWSER]
-    : ['Chrome', 'Firefox']
+    : ['ChromeHeadlessNoSandbox', 'Firefox']
 
   config.set({
     browsers,
     concurrency: 1,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
     files,
     frameworks: ['browserify', 'mocha'],
     preprocessors,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { join } = require('path')
+
+function makeConf (config) {
+  const files = [
+    join(__dirname, 'test', 'browser', 'index.js')
+  ]
+
+  const preprocessors = files.reduce((preprocessors, file) =>
+    Object.assign({ [file]: 'browserify' }, preprocessors), {})
+
+  const browsers = process.env.BROWSER
+    ? [process.env.BROWSER]
+    : ['Chrome', 'Firefox']
+
+  config.set({
+    browsers,
+    concurrency: 1,
+    files,
+    frameworks: ['browserify', 'mocha'],
+    preprocessors,
+    reporters: ['spec'],
+    singleRun: true
+  })
+}
+
+module.exports = makeConf

--- a/lib/base.js
+++ b/lib/base.js
@@ -13,6 +13,7 @@ const Parser = require('tap-parser')
 
 const ownOr = require('own-or')
 const ownOrEnv = require('own-or-env')
+const hrtime = require('browser-process-hrtime')
 
 class Base extends MiniPass {
   constructor (options) {
@@ -68,7 +69,7 @@ class Base extends MiniPass {
 
   setTimeout (n) {
     if (!this.hrtime)
-      this.hrtime = process.hrtime()
+      this.hrtime = hrtime()
 
     if (!this.start)
       this.start = Date.now()
@@ -153,7 +154,7 @@ class Base extends MiniPass {
 
   oncomplete (results) {
     if (this.hrtime) {
-      this.hrtime = process.hrtime(this.hrtime)
+      this.hrtime = hrtime(this.hrtime)
       this.time = Math.round(this.hrtime[0] * 1e6 + this.hrtime[1] / 1e3) / 1e3
     }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -53,7 +53,8 @@ class Base extends MiniPass {
     if (skip || todo)
       this.main = Base.prototype.main
 
-    domain.create().add(this)
+    this.domain = domain.create()
+    this.domain.add(this)
     this.domain.on('error', er => this.threw(er))
 
     const doDebug = typeof options.debug === 'boolean' ? options.debug

--- a/lib/clean-yaml-object.js
+++ b/lib/clean-yaml-object.js
@@ -35,7 +35,7 @@ const cleanTapYamlObject = object => {
 }
 
 const yamlFilter = (propertyName, isRoot, source, target) =>
-  source instanceof Domain ? false
+  Domain && source instanceof Domain ? false
     : !isRoot ? true
     : propertyName === 'stack' ? (
       (source.stack ? target.stack = source.stack : false), false)

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const writeFile = require('write-file-atomic')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
@@ -75,6 +74,7 @@ class Snapshot {
             escape(this.snapshot[s])
           }\n\`\n`).join('\n'))
       mkdirp.sync(path.dirname(this.file))
+      const writeFile = require('write-file-atomic')
       writeFile.sync(this.file, data, 'utf8')
     }
   }

--- a/lib/stack.js
+++ b/lib/stack.js
@@ -17,15 +17,25 @@ const skip = (process.cwd() !== tapDir ||
 ? [
     /node_modules[\/\\]tap[\/\\]/,
     new RegExp(resc(path.resolve(osHomedir(), '.node-spawn-wrap-')) + '.*'),
-    new RegExp(resc(tapDir) + '\\b', 'i'),
-    new RegExp(resc(require.resolve('function-loop'))),
-    new RegExp(resc(path.dirname(require.resolve('bluebird/package.json'))))
-  ]
+    new RegExp(resc(tapDir) + '\\b', 'i')
+  ].concat(/* istanbul ignore next */ require.resolve
+    ? [
+        new RegExp(resc(require.resolve('function-loop'))),
+        new RegExp(resc(path.dirname(require.resolve('bluebird/package.json'))))
+      ]
+    : [])
 : []
 
 sourceMapSupport.install({environment:'node'})
 
+let nodeInternals = []
+try {
+  nodeInternals = StackUtils.nodeInternals()
+} catch (error) {
+  // Do nothing.
+}
+
 module.exports = new StackUtils({
-  internals: StackUtils.nodeInternals().concat(skip),
+  internals: nodeInternals.concat(skip),
   wrapCallSite: sourceMapSupport.wrapCallSite
 })

--- a/lib/stdio-polyfill.js
+++ b/lib/stdio-polyfill.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { Writable } = require('stream')
+
+function polyfill () {
+  if (!process.stdout) {
+    process.stdout = new Writable({
+      write (chunks, encoding, cb) {
+        console.log(chunks.toString('utf-8'))
+        process.nextTick(cb)
+      }
+    })
+  }
+
+  if (!process.stderr) {
+    process.stderr = new Writable({
+      write (chunks, encoding, cb) {
+        console.error(chunks.toString('utf-8'))
+        process.nextTick(cb)
+      }
+    })
+  }
+}
+
+module.exports = polyfill

--- a/lib/tap.js
+++ b/lib/tap.js
@@ -7,6 +7,10 @@ const objToYaml = require('./obj-to-yaml.js')
 const yaml = require('js-yaml')
 const _didPipe = Symbol('_didPipe')
 
+if (!process.stdout) {
+  require('./stdio-polyfill')()
+}
+
 const monkeypatchEpipe = () => {
   const emit = process.stdout.emit
   process.stdout.emit = function (ev, er) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -25,6 +25,7 @@ const Pool = require('yapool')
 const TestPoint = require('./point.js')
 const parseTestArgs = require('./parse-test-args.js')
 const loop = require('function-loop')
+const captureStackTrace = require('capture-stack-trace')
 const path = require('path')
 
 const extraFromError = require('./extra-from-error.js')
@@ -39,6 +40,12 @@ const ownOrEnv = require('own-or-env')
 const Promise = require('bluebird')
 const bindObj = require('bind-obj-methods')
 const cwd = process.cwd()
+
+// TODO: Update stack-utils to use capture-stack-trace, too.
+/* istanbul ignore next */
+if (!Error.captureStackTrace) {
+  Error.captureStackTrace = captureStackTrace
+}
 
 // A sigil object for implicit end() calls that should not
 // trigger an error if the user then calls t.end()
@@ -497,7 +504,7 @@ class Test extends Base {
           : 'test count exceeds plan'
 
       const er = new Error(failMessage)
-      Error.captureStackTrace(er, fn)
+      captureStackTrace(er, fn)
       er.test = this.name
       er.plan = this.planEnd
       this.threw(er)
@@ -623,7 +630,7 @@ class Test extends Base {
       if (this.explicitEnded) {
         this.multiEndThrew = true
         const er = new Error('test end() method called more than once')
-        Error.captureStackTrace(er, this[_currentAssert] ||
+        captureStackTrace(er, this[_currentAssert] ||
           Test.prototype[_end])
         er.test = this.name
         this.threw(er)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "tap": "bin/run.js"
   },
+  "browser": {
+    "domain": "domain-browser"
+  },
   "main": "lib/tap.js",
   "engines": {
     "node": ">=4"
@@ -19,6 +22,7 @@
     "clean-yaml-object": "^0.1.0",
     "color-support": "^1.1.0",
     "coveralls": "^2.13.3",
+    "domain-browser": "^1.2.0",
     "foreground-child": "^1.3.3",
     "fs-exists-cached": "^1.0.0",
     "function-loop": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bind-obj-methods": "^1.0.0",
     "bluebird": "^3.5.1",
+    "browser-process-hrtime": "^0.1.2",
     "clean-yaml-object": "^0.1.0",
     "color-support": "^1.1.0",
     "coveralls": "^2.13.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bind-obj-methods": "^1.0.0",
     "bluebird": "^3.5.1",
     "browser-process-hrtime": "^0.1.2",
+    "capture-stack-trace": "^1.0.0",
     "clean-yaml-object": "^0.1.0",
     "color-support": "^1.1.0",
     "coveralls": "^2.13.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "regen-fixtures": "node scripts/generate-test-test.js test-legacy/test/*.js",
     "snap": "TAP_SNAPSHOT=1 node bin/run.js test/*.js",
     "test": "node bin/run.js test/*.js --100 -J --nyc-arg=--include={lib,bin} -c",
-    "test-all": "node bin/run.js test/*.js test-legacy/*.js --100 -J --nyc-arg=--include={lib,bin}",
+    "test-all": "node bin/run.js test/*.js test-legacy/*.js --100 -J --nyc-arg=--include={lib,bin} && npm run test-browser",
+    "test-browser": "karma start karma.conf.js",
     "unit": "bash scripts/unit.sh",
     "test-legacy": "node bin/run.js test-legacy/*.* --coverage -t3600 --nyc-arg=--include={lib,bin}",
     "smoke": "node bin/run.js --node-arg=test-legacy/test.js test-legacy/test/*.js -j2",
@@ -71,6 +72,13 @@
     "postpublish": "git push origin --all; git push origin --tags"
   },
   "devDependencies": {
+    "karma": "^2.0.0",
+    "karma-browserify": "^5.2.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
+    "karma-mocha": "^1.3.0",
+    "karma-spec-reporter": "0.0.32",
+    "mocha": "^5.0.1",
     "standard": "^7.1.2",
     "which": "^1.1.1"
   },

--- a/tap-snapshots/test-tap.js-TAP.test.js
+++ b/tap-snapshots/test-tap.js-TAP.test.js
@@ -511,3 +511,25 @@ tear it down
 exports[`test/tap.js TAP autoend=false with teardown > stderr 1`] = `
 
 `
+
+exports[`test/tap.js TAP process.stdout and process.stderr are missing > exit status 1`] = `
+{ code: 0, signal: null }
+`
+
+exports[`test/tap.js TAP process.stdout and process.stderr are missing > stdout 1`] = `
+TAP version 13
+
+ok 1 - stdout gets polyfilled
+
+ok 2 - stderr gets polyfilled
+
+1..2
+
+# {time}
+
+
+`
+
+exports[`test/tap.js TAP process.stdout and process.stderr are missing > stderr 1`] = `
+
+`

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -1,0 +1,22 @@
+/* global describe, it */
+'use strict'
+
+const assert = require('assert')
+const Parser = require('tap-parser')
+
+const { Test } = require('../..')
+
+describe('Test', () => {
+  it('it works in the browser', async () => {
+    const results = await new Promise(resolve => {
+      const parser = new Parser(resolve)
+      const test = new Test({ autoend: true })
+      test.pipe(parser)
+      test.test('Simple Arithmetic', t => {
+        t.equal(2 + 2, 4, 'two plus two equals four')
+        t.end()
+      })
+    })
+    assert.equal(results.pass, 1)
+  })
+})

--- a/test/stdio-polyfill.js
+++ b/test/stdio-polyfill.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const t = require('..')
+
+const polyfill = require('../lib/stdio-polyfill')
+
+function testProcessPolyfill (t, streamName) {
+  const methodName = streamName === 'stdout' ? 'log' : 'error'
+  const stream = process[streamName]
+  delete process[streamName]
+  polyfill()
+  t.ok(process[streamName], `${streamName} gets polyfilled`)
+  const method = console[methodName]
+  let result
+  console[methodName] = _result => { result = _result }
+  process[streamName].write('foo')
+  t.equal(result, 'foo')
+  console[methodName] = method
+  process[streamName] = stream
+  t.end()
+}
+
+t.test('when process.stdout is missing', t => testProcessPolyfill(t, 'stdout'))
+t.test('when process.stderr is missing', t => testProcessPolyfill(t, 'stderr'))

--- a/test/tap.js
+++ b/test/tap.js
@@ -119,6 +119,19 @@ const cases = {
       t.end()
     }, 50)
   },
+  'process.stdout and process.stderr are missing': t => {
+    const stdout = process.stdout
+    const stderr = process.stderr
+    delete process.stdout
+    delete process.stderr
+    delete require.cache[require.resolve('..')]
+    require('..')
+    t.ok(process.stdout, 'stdout gets polyfilled')
+    t.ok(process.stderr, 'stderr gets polyfilled')
+    process.stdout = stdout
+    process.stderr = stderr
+    t.end()
+  }
 }
 
 const main = t => {


### PR DESCRIPTION
Hi, I updated @formula1's PR, #356. I also added a Karma test that uses karma-mocha to test the browserified version of tap. Eventually, I'd like to test the browserified version with an updated karma-tap (or a karma-node-tap), but there are still details to iron out there (e.g., just parse `console.log` like karma-tap, or expose a global TAP/Test instance and hook into its Readable Stream).