### PR TITLE
docs: add unique page titles

### DIFF
--- a/docs/100/index.md
+++ b/docs/100/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: The TAP 100
 ---
 
 # The TAP 100

--- a/docs/_layouts/layout.html
+++ b/docs/_layouts/layout.html
@@ -1,5 +1,11 @@
 <!doctype html>
-<title>{{ site.title }}</title>
+<title>
+  {% if page.title %}
+    {{ page.title }} | {{ site.title }}
+  {% else %}
+    {{ site.title }}
+  {% endif %}
+</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 html {

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Advanced Usage
 ---
 
 # Advanced Usage

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: API
 ---
 
 # API

--- a/docs/asserts/index.md
+++ b/docs/asserts/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Asserts
 ---
 
 # Asserts

--- a/docs/basics/index.md
+++ b/docs/basics/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Getting Started
 ---
 
 # tap basics

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Change Log
 ---
 
 ## 11.0 2017-11-26

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: CLI
 ---
 
 # CLI

--- a/docs/coverage/index.md
+++ b/docs/coverage/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Coverage
 ---
 
 # Coverage

--- a/docs/grep/index.md
+++ b/docs/grep/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Filtering Tests&#58; Grep
 ---
 
 # Filtering Tests with Grep Options
@@ -88,15 +89,15 @@ TAP version 13
             ok 1 - apples are tasty
             1..1
         ok 1 - apple # time=8.892ms
-        
+
         # Subtest: banana
             ok 1 - bananas are yellow
             1..1
         ok 2 - banana # time=1.297ms
-        
+
         1..2
     ok 1 - first # time=18.544ms
-    
+
     ok 2 - second # SKIP filter: /first/
     1..2
     # skip: 1
@@ -206,7 +207,7 @@ TAP version 13
         ok 1 - apples are tasty
         1..1
     ok 1 - apple # time=5.166ms
-    
+
     ok 2 - banana # SKIP filter: /p/i
     1..2
     # skip: 1
@@ -217,7 +218,7 @@ ok 1 - first # time=11.805ms
         ok 1 - i think
         1..1
     ok 1 - this is fine # time=0.86ms
-    
+
     ok 2 - i am ok with how things are proceeding # SKIP filter: /fi[ln]e/
     1..2
     # skip: 1
@@ -252,7 +253,7 @@ TAP version 13
         ok 1 - apples are tasty
         1..1
     ok 1 - apple # time=4.35ms
-    
+
     ok 2 - banana # SKIP filter: /apple/
     1..2
     # skip: 1
@@ -279,7 +280,7 @@ ok 1 - first # SKIP filter out: /first/
         ok 1 - therefor I am
         1..1
     ok 2 - i am ok with how things are proceeding # time=3.117ms
-    
+
     1..2
     # skip: 1
 ok 2 - second # time=9.441ms

--- a/docs/mochalike/index.md
+++ b/docs/mochalike/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Mocha-like DSL
 ---
 
 # Mocha-like DSL

--- a/docs/only/index.md
+++ b/docs/only/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Filtering Tests&#58; Only
 ---
 
 # Filtering Tests with Only Option
@@ -152,7 +153,7 @@ TAP version 13
         ok 1 - got here
         1..1
     ok 2 - first child # time=1.609ms
-    
+
     ok 3 - second child # SKIP filter: only
     1..3
     # skip: 1

--- a/docs/parallel/index.md
+++ b/docs/parallel/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Parallel Tests
 ---
 
 # Parallel Tests

--- a/docs/promises/index.md
+++ b/docs/promises/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Promises
 ---
 
 # Promises

--- a/docs/reporting/index.md
+++ b/docs/reporting/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Reporting
 ---
 
 # Reporting

--- a/docs/snapshots/index.md
+++ b/docs/snapshots/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Testing with Snapshots
 ---
 
 # Testing with Snapshots

--- a/docs/subtests/index.md
+++ b/docs/subtests/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Subtests
 ---
 
 # Subtests
@@ -46,7 +47,7 @@ TAP version 13
         1..1
         ok 1 - this is fine
     ok 1 - bar # time=1.831ms
-    
+
     1..1
 ok 1 - foo # time=11.106ms
 
@@ -81,7 +82,7 @@ ok 1 - foo {
         1..1
         ok 1 - this is fine
     }
-    
+
     1..1
 }
 
@@ -103,7 +104,7 @@ ok 1 - foo
         1..1
         ok 1 - this is fine
     }
-    
+
     1..1
 }
 

--- a/docs/tap-format/index.md
+++ b/docs/tap-format/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layout
+title: Test Anything Protocol
 ---
 
 # Test Anything Protocol
@@ -110,7 +111,7 @@ about a test point.
 
 A test point can be marked as `todo` to indicate that it is going to
 be implemented later, or `skip` to indicate that the test should not
-be performed in the given context.  `todo` and `skip` are 
+be performed in the given context.  `todo` and `skip` are
 
 A test point associated with a
 Subtest can also have a `# time=...` directive indicating how long the


### PR DESCRIPTION
This patch adds unique page titles to the website. When a `title` is present in the page frontmatter, the layout will use it. When a title is not specified, the default `site.title` is used.

This makes navigating through the site much easier, especially when browsing with multiple tabs.