### PR TITLE
Add hexagonal-lambda to the tap 100 list

### DIFF
--- a/docs/100/index.md
+++ b/docs/100/index.md
@@ -23,6 +23,7 @@ to add it to the docs.
 * [fs-minipass](https://www.npmjs.com/package/fs-minipass)
 * [fs-readstream-seek](https://www.npmjs.com/package/fs-readstream-seek)
 * [function-loop](https://www.npmjs.com/package/function-loop)
+* [hexagonal-lambda](https://github.com/focusaurus/hexagonal-lambda)
 * [hoodie](https://www.npmjs.com/package/hoodie)
 * [icepick](https://www.npmjs.com/package/icepick)
 * [ignore-walk](https://www.npmjs.com/package/ignore-walk)


### PR DESCRIPTION
Note this is not an npm package, it's a node application for AWS lambda, but it uses `tap --100`. If you want this list to only include published npm packages, feel free to close without merging. I'd also be OK putting a `(sample project, not npm package)` note next to this or something along those lines.