### PR TITLE
support multiple coverage reports

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -101,12 +101,16 @@ Options:
   --coverage-report=<type>    Output coverage information using the
                               specified istanbul/nyc reporter type.
 
-                              Default is 'text' when running on the
-                              command line, or 'text-lcov' when piping
-                              to coveralls.
+                              Default is 'text' when running on the command
+                              line, or 'text-lcov' when piping to coveralls.
+                              This can be specified multiple times to
+                              select more than one reporter.
 
                               If 'html' is used, then the report will
                               be opened in a web browser after running.
+
+                              If 'nyc-default' is used, then nyc will be
+                              deferred to and choose it's own reporters.
 
                               This can be run on its own at any time
                               after a test run that included coverage.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -113,12 +113,16 @@ Options:
   --coverage-report=<type>    Output coverage information using the
                               specified istanbul/nyc reporter type.
 
-                              Default is 'text' when running on the
-                              command line, or 'text-lcov' when piping
-                              to coveralls.
+                              Default is 'text' when running on the command
+                              line, or 'text-lcov' when piping to coveralls.
+                              This can be specified multiple times to
+                              select more than one reporter.
 
                               If 'html' is used, then the report will
                               be opened in a web browser after running.
+
+                              If 'nyc-default' is used, then nyc will be
+                              deferred to and choose it's own reporters.
 
                               This can be run on its own at any time
                               after a test run that included coverage.

--- a/tap-snapshots/test-run.js-TAP.test.js
+++ b/tap-snapshots/test-run.js-TAP.test.js
@@ -136,6 +136,42 @@ end_of_record
 
 `
 
+exports[`test/run.js TAP coverage multiple reports > 3 text reporter outputs 1`] = `
+TN:
+SF:{CWD}/ok.js
+FN:2,(anonymous_0)
+FNF:1
+FNH:1
+FNDA:2,(anonymous_0)
+DA:2,2
+DA:3,2
+DA:4,2
+DA:6,0
+LF:4
+LH:3
+BRDA:3,0,0,2
+BRDA:3,0,1,0
+BRDA:4,1,0,2
+BRDA:4,1,1,1
+BRF:4
+BRH:3
+end_of_record
+-|-|-|-|-|-|
+File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Lines |
+-|-|-|-|-|-|
+All files | 75 | 75 | 100 | 75 | |
+ ok.js | 75 | 75 | 100 | 75 | 6 |
+-|-|-|-|-|-|
+
+=============================== Coverage summary ===============================
+Statements   : 75% ( 3/4 )
+Branches     : 75% ( 3/4 )
+Functions    : 100% ( 1/1 )
+Lines        : 75% ( 3/4 )
+================================================================================
+
+`
+
 exports[`test/run.js TAP coverage report with checks > lcov output and 100 check 1`] = `
 TN:
 SF:{CWD}/ok.js

--- a/test/run.js
+++ b/test/run.js
@@ -152,7 +152,7 @@ t.test('dump config stuff', t => {
         bail: false,
         saveFile: 'foo.txt',
         pipeToService: Boolean,
-        coverageReport: 'lcov',
+        coverageReporters: ['json', 'lcov'],
         browser: false,
         coverage: true,
         checkCoverage: true,
@@ -200,14 +200,16 @@ t.test('dump config stuff', t => {
       '--test-arg',
       '--nyc-arg',
       '--output-file',
-      '--grep'
+      '--grep',
+      '--coverage-report'
     ]
     const expect = {
       nodeArgs: [],
       testArgs: [],
       nycArgs: [],
       outputFile: null,
-      grep: []
+      grep: [],
+      coverageReporters: []
     }
     t.plan(opts.length)
     opts.forEach(opt => t.test(opt, t => run([
@@ -421,6 +423,16 @@ t.test('coverage', t => {
     escape(['--coverage-report=text-lcov'], null, (er, o, e) => {
       t.equal(er, null)
       t.matchSnapshot(clean(o), 'lcov output', { skip: winSkip })
+      t.end()
+    })
+  })
+
+  t.test('multiple reports', t => {
+    escape(['--coverage-report=text-lcov',
+            '--coverage-report=text',
+            '--coverage-report=text-summary'], null, (er, o, e) => {
+      t.equal(er, null)
+      t.matchSnapshot(clean(o), '3 text reporter outputs')
       t.end()
     })
   })


### PR DESCRIPTION
Multiple coverage reports are supported either by using comma separate values on
the command line, or by letting nyc handle the absence of any reporters.  nyc
will either use the reporters in it's own config file, or default to the text
behavior as tap did previously.

ref #274