### PR TITLE
RFC: bin/run: Add --reporter-options

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -127,6 +127,7 @@ const constructDefaultArgs = _ => {
     timeout: +process.env.TAP_TIMEOUT || defaultTimeout,
     color: !!colorSupport.level,
     reporter: null,
+    reporterOptions: {},
     files: [],
     grep: [],
     grepInvert: false,
@@ -280,6 +281,10 @@ const parseArgs = (args, options) => {
 
       case '--reporter':
         options.reporter = val || args[++i]
+        continue
+
+      case '--reporter-options':
+        options.reporterOptions = JSON.parse(val || args[++i])
         continue
 
       case '--gc': case '-gc': case '--expose-gc':
@@ -595,9 +600,9 @@ const setupTapEnv = options => {
 const globFiles = files => files.reduce((acc, f) =>
   acc.concat(f === '-' ? f : glob.sync(f, { nonull: true })), [])
 
-const makeReporter = options =>
-  new (require('tap-mocha-reporter'))(options.reporter)
-
+const makeReporter = options => {
+  return new (require('tap-mocha-reporter'))(options.reporter, {}, options.reporterOptions)
+}
 const stdinOnly = options => {
   // if we didn't specify any files, then just passthrough
   // to the reporter, so we don't get '/dev/stdin' in the suite list.

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -62,6 +62,11 @@ Options:
                               Available reporters:
 @@REPORTERS@@
 
+  --reporter-options=<opts>   Configure the specified reporter with a
+                              JSON value.  For example, you could use
+                              '{"reporter": {"open": "(", "close": ")"}}'
+                              to customize the progress reporter.
+
   -o<file>                    Send the raw TAP output to the specified
   --output-file=<file>        file.  Reporter output will still be
                               printed to stdout, but the file will

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -74,6 +74,11 @@ Options:
                               landing list markdown min nyan progress
                               silent spec tap xunit
 
+  --reporter-options=<opts>   Configure the specified reporter with a
+                              JSON value.  For example, you could use
+                              `{"reporter": {"open": "(", "close": ")"}}`
+                              to customize the progress reporter.
+
   -o<file>                    Send the raw TAP output to the specified
   --output-file=<file>        file.  Reporter output will still be
                               printed to stdout, but the file will

--- a/docs/reporting/index.md
+++ b/docs/reporting/index.md
@@ -86,3 +86,11 @@ The following options are available:
 - xunit
 
     XML output popular in .NET land.
+
+You can pass options to those reporters using `--reporter-options`
+with a JSON value.  For example:
+
+```
+--reporter=progress
+--reporter-options='{"reporter": {"open": "(", "close": ")"}}'
+```

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "signal-exit": "^3.0.0",
     "source-map-support": "^0.5.6",
     "stack-utils": "^1.0.0",
-    "tap-mocha-reporter": "^3.0.7",
+    "tap-mocha-reporter": "FIXME: bump to contain https://github.com/tapjs/tap-mocha-reporter/pull/49 once it lands",
     "tap-parser": "^7.0.0",
     "tmatch": "^4.0.0",
     "trivial-deferred": "^1.0.1",


### PR DESCRIPTION
This PR depends on tapjs/tap-mocha-reporter#49; review that first.

This is inspired by [Mocha's][1]:

```
  --reporter-options <k=v,k2=v2,...>
```

Except:

* I'm using a JSON value for easier parsing and more explicit typing.  This will end up using a few more characters, but the format is more explicit than Mocha's (which only uses string values?).  And callers are likely to already be familiar with JSON, so we save the mental overhead of teaching them a new serialization format.

* I'm using a `reporter` namespace.  This allows us to add other namespaces in the future to address other configurable aspects of tap-mocha-reporter's `Formatter`.  For example, we could use this same CLI option to configure the runner.

Somewhat related to this, if we have plans for allowing multiple reporters (#335), we may want to namespace *those* now.  For example:

```
  --reporter-options {"reporter": {"progress": {"open": "(", "close": ")"}}}
```

to avoid [the issues Mocha bumped into][3] when trying to add multi-reporter support.

[1]: https://mochajs.org/#usage
[2]: https://github.com/tapjs/node-tap/issues/335
[3]: https://github.com/mochajs/mocha/pull/2184#issuecomment-351556819