### PR TITLE
Output plan when using CLI with -j option

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -753,12 +753,17 @@ const runTests = options => {
 
   // if not -Rtap, then output what the user wants.
   // otherwise just dump to stdout
-  tap.pipe(options.reporter === 'tap' ? process.stdout: makeReporter(options))
+  const outStream = options.reporter === 'tap' ? process.stdout : makeReporter(options)
+
+  tap.pipe(outStream)
 
   // need to replay the first version line, because the previous
   // line will have flushed it out to stdout or the reporter already.
   if (options.outputFile !== null)
     tap.pipe(fs.createWriteStream(options.outputFile)).write('TAP version 13\n')
+
+  if (options.files.length > 1 && options.jobs > 1)
+    outStream.write(`1..${options.files.length}\n`)
 
   saveFails(options, tap)
 

--- a/tap-snapshots/test-run.js-TAP.test.js
+++ b/tap-snapshots/test-run.js-TAP.test.js
@@ -349,6 +349,7 @@ ok 4 - x/y/1.js # {time}
 
 exports[`test/run.js TAP parallel > output 1`] = `
 TAP version 13
+1..5
 ok 1 - p/y/1.js # {time} {
     ok 1 - one
     1..1


### PR DESCRIPTION
When using the -j option the tap output did not include the plan. This PR tries to fix this issue.

I look forward to getting some feedback on the correctness of this solution.