### PR TITLE
fix: sigquit not supported on appveyor win

### DIFF
--- a/test/spawn.js
+++ b/test/spawn.js
@@ -172,7 +172,7 @@ switch (process.argv[2]) {
 
   case 'sigself':
     setTimeout(_ =>
-      process.kill(process.pid, 'SIGQUIT'), 300)
+      process.kill(process.pid, 'SIGTERM'), 300)
     break
 
   case 'not-ok':


### PR DESCRIPTION
The (Windows specific) SIGQUIT signal in the tests broke testing on AppVeyor.