### PR TITLE
Add 'identical' to synonyms

### DIFF
--- a/lib/synonyms.js
+++ b/lib/synonyms.js
@@ -27,7 +27,7 @@ module.exports = multiword({
   // exactly the same.  ===
   equal: [
     'equals', 'isEqual', 'is', 'strictEqual', 'strictEquals', 'strictIs',
-    'isStrict', 'isStrictly'
+    'isStrict', 'isStrictly', 'identical'
   ],
 
   // not equal.  !==


### PR DESCRIPTION
This adds 'identical' as synonym to equal. To have a certain symmetry to same's 'equivalent'.