### PR TITLE
WIP: allow for pipes to drain

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -182,7 +182,8 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    super.end()
+    !this.flowing && this.buffer.length && this.resume()
+    this.emit('end')
     this.ondone()
   }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -182,7 +182,7 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    this.emit('end')
+    super.end()
     this.ondone()
   }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -182,8 +182,11 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    !this.flowing && this.buffer.length && this.resume()
-    this.emit('end')
+    if (!this.flowing && this.buffer.length) {
+      super.end()
+    } else {
+      this.emit('end')
+    }
     this.ondone()
   }
 


### PR DESCRIPTION
When running with -j, --output-file and --reporter options and when the child test output is big enough, some data may still be buffered and not yet passed to this.pipes. Firing the 'end' event will end the pipes, which will then fail because of unfinished parsing. Calling super.end, will properly check for pending drains.