### PR TITLE
Don't emit end while waiting for pipes to clear

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -182,7 +182,8 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    super.end()
+    !this.flowing && this.buffer.length && this.resume()
+    this.emit('end')
     this.ondone()
   }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -182,16 +182,25 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    if (!this.flowing && this.buffer.length) {
+    // if we're piping, and buffered, then it means we need to hold off
+    // on emitting 'end' and calling ondone() until the pipes clear out.
+    if (this.pipes.length && this.buffer.length)
       super.end()
-    } else {
+    else
       this.emit('end')
-    }
-    this.ondone()
   }
 
   onbeforeend () {}
   ondone () {}
+
+  emit (ev, data) {
+    if (ev === 'end') {
+      const ret = super.emit(ev, data)
+      this.ondone()
+      return ret
+    } else
+      return super.emit(ev, data)
+  }
 
   setupParser (options) {
     this.parser = new Parser({

--- a/lib/base.js
+++ b/lib/base.js
@@ -182,7 +182,7 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    this.emit('end')
+    super.end()
     this.ondone()
   }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -182,8 +182,11 @@ class Base extends MiniPass {
       this.options.failures = failures
 
     this.onbeforeend()
-    !this.flowing && this.buffer.length && this.resume()
-    this.emit('end')
+    if (!this.flowing && this.buffer.length) {
+      super.end()
+    } else {
+      this.emit('end')
+    }
     this.ondone()
   }
 

--- a/test/regression-pipe-backup.js
+++ b/test/regression-pipe-backup.js
@@ -1,0 +1,10 @@
+'use strict'
+
+// https://github.com/tapjs/node-tap/pull/506
+
+const t = require('../')
+
+t.plan(5000)
+for (let i = 1; i <= 5000; i++) {
+  t.pass(i)
+}


### PR DESCRIPTION
Slight tweak on #506 to avoid making a breaking change in other use cases.

@kalinkrustev can you please check to see if this fixes your issue with using `--output-file`?

Thank you very much for finding this and putting up with my pedantry around the fix :)