### PR TITLE
Fix font-family typo

### DIFF
--- a/docs/_layouts/layout.html
+++ b/docs/_layouts/layout.html
@@ -41,7 +41,7 @@ a:hover, a:active, a:focus {
 
 code, pre, kbd {
   font-size: 100%;
-  font-family: Triplicate T4, Fira Mono OT, Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospacek;
+  font-family: Triplicate T4, Fira Mono OT, Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 }
 
 section.side {


### PR DESCRIPTION
Fixes monospace fonts on platforms that don't have any of the named fonts, like Chromebooks.