### PR TITLE
Fix font-family typo: Part II

### DIFF
--- a/docs/static/prism.css
+++ b/docs/static/prism.css
@@ -10,7 +10,7 @@ pre[class*="language-"] {
 	color: black;
 	background: none;
 	text-shadow: 0 1px white;
-  font-family: Triplicate T4, Fira Mono OT, Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospacek;
+  font-family: Triplicate T4, Fira Mono OT, Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;


### PR DESCRIPTION
Fixes monospace fonts on platforms that don't have any of the named fonts, like Chromebooks. Like #520, but for code blocks.