### PR TITLE
Update to latest tap-mocha-reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,14 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
       "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
     },
+    "@babel/runtime": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
@@ -5511,6 +5519,11 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6390,29 +6403,29 @@
       }
     },
     "tap-mocha-reporter": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.9.tgz",
-      "integrity": "sha512-VO07vhC9EG27EZdOe7bWBj1ldbK+DL9TnRadOgdQmiQOVZjFpUEQuuqO7+rNSO2kfmkq5hWeluYXDWNG/ytXTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-4.0.1.tgz",
+      "integrity": "sha512-/KfXaaYeSPn8qBi5Be8WSIP3iKV83s2uj2vzImJAXmjNu22kzqZ+1Dv1riYWa53sPCiyo1R1w1jbJrftF8SpcQ==",
       "requires": {
         "color-support": "^1.1.0",
         "debug": "^2.1.3",
         "diff": "^1.3.2",
         "escape-string-regexp": "^1.0.3",
         "glob": "^7.0.5",
-        "js-yaml": "^3.3.1",
         "readable-stream": "^2.1.5",
-        "tap-parser": "^5.1.0",
+        "tap-parser": "^8.0.0",
+        "tap-yaml": "0 || 1",
         "unicode-length": "^1.0.0"
       },
       "dependencies": {
         "tap-parser": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
-          "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-8.1.0.tgz",
+          "integrity": "sha512-GgOzgDwThYLxhVR83RbS1JUR1TxcT+jfZsrETgPAvFdr12lUOnuvrHOBaUQgpkAp6ZyeW6r2Nwd91t88M0ru3w==",
           "requires": {
             "events-to-array": "^1.0.1",
-            "js-yaml": "^3.2.7",
-            "readable-stream": "^2"
+            "minipass": "^2.2.0",
+            "tap-yaml": "0 || 1"
           }
         }
       }
@@ -6425,6 +6438,14 @@
         "events-to-array": "^1.0.1",
         "js-yaml": "^3.2.7",
         "minipass": "^2.2.0"
+      }
+    },
+    "tap-yaml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
+      "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
+      "requires": {
+        "yaml": "^1.5.0"
       }
     },
     "test-exclude": {
@@ -7130,6 +7151,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.5.0.tgz",
+      "integrity": "sha512-nKxSWOa7vxAP2pikrGxbkZsG/garQseRiLn9mIDjzwoQsyVy7ZWIpLoARejnINGGLA4fttuzRFFNxxbsztdJgw==",
+      "requires": {
+        "@babel/runtime": "^7.4.3"
+      }
     },
     "yapool": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "signal-exit": "^3.0.0",
     "source-map-support": "^0.5.10",
     "stack-utils": "^1.0.2",
-    "tap-mocha-reporter": "^3.0.9",
+    "tap-mocha-reporter": "^4.0.0",
     "tap-parser": "^7.0.0",
     "tmatch": "^4.0.0",
     "trivial-deferred": "^1.0.1",


### PR DESCRIPTION
This should fix _some_ of the pesky js-yaml security advisories. While it was a major version bump, there weren't any breaking changes AFAIK.