### PR TITLE
fix typo in docs heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Just kidding.
 Most frameworks spend a lot of their documentation telling you why they're
 the greatest.  I'm not going to do that.
 
-### <i lang="it" title="all tastes are tastes">tutti i gusti, sono
-gusti</i>
+### <i lang="it" title="all tastes are tastes">tutti i gusti sono gusti</i>
 
 Software testing is a software and user experience design challenge that
 balances on the intersection of many conflicting demands.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Just kidding.
 Most frameworks spend a lot of their documentation telling you why they're the
 greatest.  I'm not going to do that.
 
-### <i lang="it" title="all tastes are tastes">tutti i gusti, sono gusti</i>
+### <i lang="it" title="all tastes are tastes">tutti i gusti sono gusti</i>
 
 Software testing is a software and user experience design challenge that
 balances on the intersection of many conflicting demands.


### PR DESCRIPTION
Fix typos in <q lang="it">tutti i gusti sono gusti</q> heading.

- removes linebreak that terminates heading in `README.md`
- re-apply fix from #395 (missing in `index.md`, regressed in `README.md` with 4f8351fd4b05caabf8665f66234d35864b312c38)