### PR TITLE
Upgrade Ink to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,9 +1241,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ink": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-2.2.0.tgz",
-      "integrity": "sha512-BQl7jpmLxPqFGjdQdgXQS0+mAyn1BHkEW1YXur3dahNNwLB6MWsfAZ1GWVdj+Mbpmj+u33KaFOosw3067t3d9g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-2.3.0.tgz",
+      "integrity": "sha512-931rgXHAS3hM++8ygWPOBeHOFwTzHh3pDAVZtiBVOUH6tVvJijym43ODUy22ySo2NwYUFeR/Zj3xuWzBEKMiHw==",
       "requires": {
         "@types/react": "^16.8.6",
         "arrify": "^1.0.1",


### PR DESCRIPTION
Fixes https://github.com/tapjs/node-tap/issues/574.

Latest release includes significant performance improvements for `<Static>` component, see more at https://github.com/vadimdemedes/ink/commit/78be775973ac234b0ae5e2e65c662fd0297eb038.