### PR TITLE
Pull initial TS_NODE_COMPILER_OPTIONS from test-env

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -652,7 +652,7 @@ const runAllFiles = (options, env, tap, processDB) => {
       if (options.ts && /\.tsx?$/.test(file)) {
         debug('ts file', file)
         const compilerOpts = JSON.stringify({
-          ...JSON.parse(process.env.TS_NODE_COMPILER_OPTIONS || '{}'),
+          ...JSON.parse(env.TS_NODE_COMPILER_OPTIONS || '{}'),
           jsx: 'react'
         })
         opt.env = {


### PR DESCRIPTION
Currently, this setup in package.json is half ignored:

```json
{
  "tap": {
    "test-env": [
      "TS_NODE_TRANSPILE_ONLY=1",
      "TS_NODE_COMPILER_OPTIONS={\"module\":\"commonjs\"}"
    ]
  }
}
```

the tests are run as:

```
  test: TAP
  env:
    TS_NODE_TRANSPILE_ONLY: "1"
    TS_NODE_COMPILER_OPTIONS: '{"jsx":"react"}'
```

After the fix, they are run as:

```
  test: TAP
  env:
    TS_NODE_TRANSPILE_ONLY: "1"
    TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs","jsx":"react"}'
```

I understand that you will need regression tests etc. etc., consider this a heads up not the actual PR.