### PR TITLE
add: link to replit run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 !scripts/
 !tap-snapshots/
 !test/
+!.replit
 !.travis.yml
 !.gitignore
 !.gitattributes

--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "cd example && node long-slow-many.js"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A <abbr title="Test Anything Protocol">TAP</abbr> test framework for
 Node.js.
 
 [![Build Status](https://travis-ci.org/tapjs/node-tap.svg?branch=master)](https://travis-ci.org/tapjs/node-tap)
+[![run on repl.it](http://repl.it/badge/github/tapjs/node-tap)](https://repl.it/github/tapjs/node-tap)
 
 _Just wanna see some code? [Get started!](http://www.node-tap.org/basics/)_
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-node-tap):

![image](https://i.imgur.com/VpaHjai.png)
