### PR TITLE
Add other operating systems to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ node_js:
 
 os:
   - linux
+  - osx
+  - windows
 
 cache:
   directories:


### PR DESCRIPTION
Problem: I've noticed some Windows-specific test failures that look
confusing, and it would be great to confirm that these failures aren't
coming from node-tap itself. After seeing a Windows-specific bug fix
(a9bd8f3) it seems like maybe if there were other Windows-specific bugs
we wouldn't know about them until someone brought them up.

Solution: Add macOS and Windows to `.travis.yml` to get automated
testing on those platforms as well.