### PR TITLE
add clear-folder to the TAP 100 list

### DIFF
--- a/docs/src/content/docs/coverage/100/index.md
+++ b/docs/src/content/docs/coverage/100/index.md
@@ -18,6 +18,7 @@ to add it to the docs.
 
 * [abbrev](https://www.npmjs.com/package/abbrev)
 * [casern](https://www.npmjs.com/package/casern)
+* [clear-folder](https://www.npmjs.com/package/clear-folder)
 * [color-support](https://www.npmjs.com/package/color-support)
 * [contentfs](https://www.npmjs.com/package/contentfs)
 * [dotenv](https://www.npmjs.com/package/dotenv)


### PR DESCRIPTION
Could you add clear-folder to the TAP 100 list?
Coverage check was setup after the last npm publish, it can be seen at https://github.com/ovanderzee/clear-folder.