### PR TITLE
Add mock API

### DIFF
--- a/docs/src/content/docs/api/mocks/index.md
+++ b/docs/src/content/docs/api/mocks/index.md
@@ -23,7 +23,7 @@ const myModule = t.mock('../my-module', {
   'fs': {
     readFileSync: () => throw new Error('oh no')
   },
-  './util/my-helper.js': {
+  '../util/my-helper.js': {
     foo: () => 'bar'
   }
 })
@@ -33,15 +33,15 @@ const myModule = t.mock('../my-module', {
 
 ## Do not mess with my require.cache
 
-`t.mock()` focus in a single-pattern that consists in hijacking the internal
+`t.mock()` focus in a single pattern that consists in hijacking the internal
 `require` calls and injecting any mock you provide through that. It will not
-try to replace modules from Node's internal `require.cache` or really do any
-extra work other than that.
+try to replace modules from Node's internal `require.cache`.
 
 ## Alternatives
 
-In case you find yourself needing a more robust solution, here are some of
-the mocking libraries that inspired this API:
+In case you find yourself needing a more robust solution, that for example,
+also handles CommonJS cache and more. Here are some of the mocking libraries
+that inspired this API, you might want to give them a try:
 
 - [`require-inject`](https://www.npmjs.com/package/require-inject)
 - [`proxyquire`](https://www.npmjs.com/package/proxyquire)

--- a/docs/src/content/docs/api/mocks/index.md
+++ b/docs/src/content/docs/api/mocks/index.md
@@ -1,0 +1,47 @@
+---
+title: Testing with Mocks
+section:
+---
+# Testing with Mocks
+
+Mocking/Stubbing parts of the codebase is a great tool to help with
+increasing test coverage, specially in parts of the code that are harder
+to reach with integration tests.
+
+The Mock API is a helper that makes it easy to swap internally required
+modules with any artificial replacement you might need in the current tests.
+
+Using `t.mock()` in practice is as simple as:
+
+```js
+// in tests you would usually require a module to be tested, like:
+// const myModule = require('../my-module')
+//
+// instead you use t.mock() to require that module and pick
+// which of its required modules to replace on the fly:
+const myModule = t.mock('../my-module', {
+  'fs': {
+    readFileSync: () => throw new Error('oh no')
+  },
+  './util/my-helper.js': {
+    foo: () => 'bar'
+  }
+})
+
+// run tests!
+```
+
+## Do not mess with my require.cache
+
+`t.mock()` focus in a single-pattern that consists in hijacking the internal
+`require` calls and injecting any mock you provide through that. It will not
+try to replace modules from Node's internal `require.cache` or really do any
+extra work other than that.
+
+## Alternatives
+
+In case you find yourself needing a more robust solution, here are some of
+the mocking libraries that inspired this API:
+
+- [`require-inject`](https://www.npmjs.com/package/require-inject)
+- [`proxyquire`](https://www.npmjs.com/package/proxyquire)

--- a/docs/src/content/docs/api/mocks/index.md
+++ b/docs/src/content/docs/api/mocks/index.md
@@ -4,21 +4,17 @@ section:
 ---
 # Testing with Mocks
 
-Mocking/Stubbing parts of the codebase is a great tool to help with
-increasing test coverage, specially in parts of the code that are harder
-to reach with integration tests.
+Mocking modules is a great tool to help with increasing test coverage,
+specially in parts of the code that are harder to reach with integration tests.
 
 The Mock API is a helper that makes it easy to swap internally required
-modules with any artificial replacement you might need in the current tests.
+modules with any replacement you might need in the current tests.
 
 Using `t.mock()` in practice is as simple as:
 
 ```js
-// in tests you would usually require a module to be tested, like:
-// const myModule = require('../my-module')
-//
-// instead you use t.mock() to require that module and pick
-// which of its required modules to replace on the fly:
+// use t.mock() to require a module while replacing
+// its internal required modules for mocked replacements:
 const myModule = t.mock('../my-module', {
   'fs': {
     readFileSync: () => throw new Error('oh no')
@@ -28,18 +24,13 @@ const myModule = t.mock('../my-module', {
   }
 })
 
-// run tests!
+// run tests, e.g:
+t.equal(myModule.fnThatUsesMyHelper(), 'bar')
 ```
-
-## Do not mess with my require.cache
-
-`t.mock()` focus in a single pattern that consists in hijacking the internal
-`require` calls and injecting any mock you provide through that. It will not
-try to replace modules from Node's internal `require.cache`.
 
 ## Alternatives
 
-In case you find yourself needing a more robust solution, that for example,
+In case you find yourself needing a more robust solution one that for example,
 also handles CommonJS cache and more. Here are some of the mocking libraries
 that inspired this API, you might want to give them a try:
 

--- a/docs/src/content/docs/structure/index.md
+++ b/docs/src/content/docs/structure/index.md
@@ -279,7 +279,9 @@ way to perform the same action in two different ways, but yielding the same
 result.  In a case like this, you can define both of them as children of a
 shared parent subtest for the feature.  In this example, we're using a
 [fixture](/docs/api/fixtures/) which will get automatically removed after
-the subtest block is completed.
+the subtest block is completed and requiring our module defining
+[mocks](/docs/api/mocks/) which is only going to be available in this scope.
+
 
 ```js
 t.test('reads symbolic links properly', t => {
@@ -288,6 +290,14 @@ t.test('reads symbolic links properly', t => {
   const dir = t.testdir({
     file: 'some file contents',
     link: t.fixture('symlink', 'file'),
+  })
+
+  // requires a module while mocking
+  // one of its internally required module
+  const myModule = t.mock('../my-module.js', {
+    fs: {
+      readFileSync: () => 'file'
+    }
   })
 
   // test both synchronously and asynchronously.

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,9 +1,13 @@
 const Module = require('module')
 
 class Mock {
-  constructor(filename, mocks) {
+  constructor(parentFilename, filename, mocks) {
     this.filename = filename
-    this.mocks = mocks
+    this.mocks = new Map()
+
+    if (!parentFilename || typeof parentFilename !== 'string') {
+      throw new TypeError('A parentFilename is required to resolve Mocks paths')
+    }
 
     if (!filename || typeof filename !== 'string') {
       throw new TypeError('t.mock() first argument should be a string')
@@ -14,10 +18,16 @@ class Mock {
 are the same used in ${filename} require calls`)
     }
 
-    const callerTestRef = module.parent.parent.parent
+    const callerTestRef = Module._cache[parentFilename]
     const filePath = Module._resolveFilename(filename, callerTestRef)
     if (!Module._cache[filePath]) {
       Module._load(filename, callerTestRef, false)
+    }
+
+    // populate mocks Map from resolved filenames
+    for (const key of Object.keys(mocks)) {
+      const mockFilePath = Module._resolveFilename(key, callerTestRef)
+      this.mocks.set(mockFilePath, mocks[key])
     }
 
     this.original = Module._cache[filePath]
@@ -28,11 +38,14 @@ are the same used in ${filename} require calls`)
       this.original
     )
 
-    mod.require = function requireMock(id) {
-      if (Object.prototype.hasOwnProperty.call(mocks, id))
-        return mocks[id]
+    const mock = this
+    mod.require = function tapRequireMock(id) {
+      const requiredFilePath = Module._resolveFilename(id, mock.original)
+      const res = mock.mocks.get(requiredFilePath)
+      if (res)
+        return res
 
-      return originalRequire.call(this, id)
+      return mock.original.require.call(this, id)
     }
 
     mod.loaded = false
@@ -40,8 +53,8 @@ are the same used in ${filename} require calls`)
     this.module = mod.exports
   }
 
-  static get(filename, mocks) {
-    const mock = new Mock(filename, mocks)
+  static get(parentFilename, filename, mocks) {
+    const mock = new Mock(parentFilename, filename, mocks)
     return mock.module
   }
 }

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,7 +1,7 @@
 const Module = require('module')
 
 class Mock {
-  constructor(parentFilename, filename, mocks) {
+  constructor(parentFilename, filename, mocks = {}) {
     this.filename = filename
     this.mocks = new Map()
 
@@ -13,22 +13,21 @@ class Mock {
       throw new TypeError('t.mock() first argument should be a string')
     }
 
-    if (!mocks || typeof mocks !== 'object') {
+    if (typeof mocks !== 'object') {
       throw new TypeError(`mocks should be a a key/value object in which keys
 are the same used in ${filename} require calls`)
     }
 
-    let reload = false
     const self = this
     const callerTestRef = Module._cache[parentFilename]
     const filePath = Module._resolveFilename(filename, callerTestRef)
+
     // populate mocks Map from resolved filenames
     for (const key of Object.keys(mocks)) {
       const mockFilePath = Module._resolveFilename(key, callerTestRef)
       this.mocks.set(mockFilePath, mocks[key])
     }
 
-    const __require = Module.prototype.require
     function tapRequireMock (id) {
       if (this.filename === filePath) {
         const requiredFilePath = Module._resolveFilename(id, this)
@@ -38,7 +37,7 @@ are the same used in ${filename} require calls`)
           return res
       }
 
-      return __require.call(this, id)
+      return Module.prototype.require.call(this, id)
     }
 
     class MockedModule extends Module {
@@ -46,9 +45,9 @@ are the same used in ${filename} require calls`)
         return tapRequireMock.call(this, id)
       }
     }
-    const mod = new MockedModule(filePath, callerTestRef)
-    mod.load(filePath)
-    this.module = mod
+
+    this.module = new MockedModule(filePath, callerTestRef)
+    this.module.load(filePath)
   }
 
   static get(parentFilename, filename, mocks) {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -18,38 +18,52 @@ class Mock {
 are the same used in ${filename} require calls`)
     }
 
+    let reload = false
+    const self = this
     const callerTestRef = Module._cache[parentFilename]
     const filePath = Module._resolveFilename(filename, callerTestRef)
-    if (!Module._cache[filePath]) {
-      Module._load(filename, callerTestRef, false)
-    }
-
     // populate mocks Map from resolved filenames
     for (const key of Object.keys(mocks)) {
       const mockFilePath = Module._resolveFilename(key, callerTestRef)
       this.mocks.set(mockFilePath, mocks[key])
     }
 
-    this.original = Module._cache[filePath]
-    const originalRequire = this.original.require
+    const __require = Module.prototype.require
+    function tapRequireMock (id) {
+      if (this.filename === filePath) {
+        const requiredFilePath = Module._resolveFilename(id, this)
+        const res = self.mocks.get(requiredFilePath)
+        if (res)
+          return res
+      }
 
-    const mod = Object.assign(
-      Object.create(Module.prototype),
-      this.original
-    )
-
-    const mock = this
-    mod.require = function tapRequireMock(id) {
-      const requiredFilePath = Module._resolveFilename(id, mock.original)
-      const res = mock.mocks.get(requiredFilePath)
-      if (res)
-        return res
-
-      return mock.original.require.call(this, id)
+      return __require.call(this, id)
     }
 
-    mod.loaded = false
-    mod.load(filePath)
+    // patch Module.prototype.require to ensure mocked modules
+    // don't get loaded when Module._load the entry filePath module
+    Module.prototype.require = tapRequireMock
+
+    if (!Module._cache[filePath])
+      Module._load(filename, callerTestRef, false)
+    else
+      reload = true
+
+    const original = Module._cache[filePath]
+    const mod = Object.assign(
+      Object.create(Module.prototype),
+      original
+    )
+
+    // release global Module.prototype.require patch
+    Module.prototype.require = __require
+    delete Module._cache[filePath]
+    mod.require = tapRequireMock
+
+    if (reload) {
+      mod.loaded = false
+      mod.load(filePath)
+    }
     this.module = mod.exports
   }
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -20,8 +20,10 @@ class Mock {
     }
 
     if (!isPlainObject(mocks)) {
-      throw new TypeError(`mocks should be a a key/value object in which keys
-are the same used in ${filename} require calls`)
+      throw new TypeError(
+        'mocks should be a a key/value object in which keys ' +
+        `are the same used in ${filename} require calls`
+      )
     }
 
     const self = this
@@ -34,27 +36,34 @@ are the same used in ${filename} require calls`)
       this.mocks.set(mockFilePath, mocks[key])
     }
 
+    // keep a cache system for non-mocked files
     const seen = new Map()
 
     class MockedModule extends Module {
       require (id) {
         const requiredFilePath = Module._resolveFilename(id, this)
 
+        // if it's a mocked file, just serve that instead
         if (self.mocks.has(requiredFilePath))
           return self.mocks.get(requiredFilePath)
 
+        // builtin, not-mocked modules need to be loaded via regular require fn
         const isWindows = process.platform === 'win32';
+        /* istanbul ignore next - platform dependent code path */
         const isRelative = id.startsWith('./') ||
           id.startsWith('../') ||
           ((isWindows && id.startsWith('.\\')) ||
           id.startsWith('..\\'))
-
         if (!isRelative && !isAbsolute(id))
           return super.require(id)
 
+        // if non-mocked file that we've seen, return that instead
+        // this enable cicle-required deps to work
         if (seen.has(requiredFilePath))
           return seen.get(requiredFilePath).exports
 
+        // load any not-mocked module via our MockedModule class
+        // also sets them in our t.mock realm cache to avoid cicles
         const unmockedModule = new MockedModule(requiredFilePath, this)
         seen.set(requiredFilePath, unmockedModule)
         unmockedModule.load(requiredFilePath)

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -28,19 +28,14 @@ are the same used in ${filename} require calls`)
       this.mocks.set(mockFilePath, mocks[key])
     }
 
-    function tapRequireMock (id) {
-      const requiredFilePath = Module._resolveFilename(id, this)
-      const res = self.mocks.get(requiredFilePath)
-
-      if (res)
-        return res
-
-      return Module.prototype.require.call(this, id)
-    }
-
     class MockedModule extends Module {
       require (id) {
-        return tapRequireMock.call(this, id)
+        const requiredFilePath = Module._resolveFilename(id, this)
+
+        if (self.mocks.has(requiredFilePath))
+          return self.mocks.get(requiredFilePath)
+
+        return super.require(id)
       }
     }
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -29,6 +29,8 @@ are the same used in ${filename} require calls`)
       this.mocks.set(mockFilePath, mocks[key])
     }
 
+    const seen = new Map()
+
     class MockedModule extends Module {
       require (id) {
         const requiredFilePath = Module._resolveFilename(id, this)
@@ -45,7 +47,11 @@ are the same used in ${filename} require calls`)
         if (!isRelative && !isAbsolute(id))
           return super.require(id)
 
+        if (seen.has(requiredFilePath))
+          return seen.get(requiredFilePath).exports
+
         const unmockedModule = new MockedModule(requiredFilePath, this)
+        seen.set(requiredFilePath, unmockedModule)
         unmockedModule.load(requiredFilePath)
         return unmockedModule.exports
       }

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -33,43 +33,32 @@ are the same used in ${filename} require calls`)
       if (this.filename === filePath) {
         const requiredFilePath = Module._resolveFilename(id, this)
         const res = self.mocks.get(requiredFilePath)
+
         if (res)
           return res
       }
 
       return __require.call(this, id)
     }
-
-    // patch Module.prototype.require to ensure mocked modules
-    // don't get loaded when Module._load the entry filePath module
-    Module.prototype.require = tapRequireMock
-
-    if (!Module._cache[filePath])
-      Module._load(filename, callerTestRef, false)
-    else
-      reload = true
-
-    const original = Module._cache[filePath]
-    const mod = Object.assign(
-      Object.create(Module.prototype),
-      original
-    )
-
-    // release global Module.prototype.require patch
-    Module.prototype.require = __require
-    delete Module._cache[filePath]
-    mod.require = tapRequireMock
-
-    if (reload) {
-      mod.loaded = false
-      mod.load(filePath)
+      // TODO: add tests for it, e.g: require.resolve usage
+    for (const key in __require) {
+        console.log('key: ', key)
+      tapRequireMock[key] = __require[key]
     }
-    this.module = mod.exports
+
+    class MockedModule extends Module {
+      require (id) {
+        return tapRequireMock.call(this, id)
+      }
+    }
+    const mod = new MockedModule(filePath, callerTestRef)
+    mod.load(filePath)
+    this.module = mod
   }
 
   static get(parentFilename, filename, mocks) {
     const mock = new Mock(parentFilename, filename, mocks)
-    return mock.module
+    return mock.module.exports
   }
 }
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -29,13 +29,11 @@ are the same used in ${filename} require calls`)
     }
 
     function tapRequireMock (id) {
-      if (this.filename === filePath) {
-        const requiredFilePath = Module._resolveFilename(id, this)
-        const res = self.mocks.get(requiredFilePath)
+      const requiredFilePath = Module._resolveFilename(id, this)
+      const res = self.mocks.get(requiredFilePath)
 
-        if (res)
-          return res
-      }
+      if (res)
+        return res
 
       return Module.prototype.require.call(this, id)
     }

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -35,7 +35,9 @@ are the same used in ${filename} require calls`)
         if (self.mocks.has(requiredFilePath))
           return self.mocks.get(requiredFilePath)
 
-        return super.require(id)
+        const unmockedModule = new MockedModule(requiredFilePath, this)
+        unmockedModule.load(requiredFilePath)
+        return unmockedModule.exports
       }
     }
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,6 +1,25 @@
 const Module = require('module')
 
+const getKey = (a, b, c) =>
+  `${a}${b}${
+    JSON.stringify(c, (_, val) => typeof val !== 'object' ? String(val) : val)
+  }`
+
 class Mock {
+  static cache () {
+    if (!this._cache)
+      this._cache = new Map()
+    return this._cache
+  }
+
+  static setToCache({ parentFilename, filename, mocks, module }) {
+    this.cache().set(getKey(parentFilename, filename, mocks), module)
+  }
+
+  static getFromCache({ parentFilename, filename, mocks }) {
+    return this.cache().get(getKey(parentFilename, filename, mocks))
+  }
+
   constructor(parentFilename, filename, mocks = {}) {
     this.filename = filename
     this.mocks = new Map()
@@ -16,6 +35,12 @@ class Mock {
     if (typeof mocks !== 'object') {
       throw new TypeError(`mocks should be a a key/value object in which keys
 are the same used in ${filename} require calls`)
+    }
+
+    const cached = Mock.getFromCache({ parentFilename, filename, mocks })
+    if (cached) {
+      this.module = cached
+      return
     }
 
     const self = this
@@ -48,6 +73,7 @@ are the same used in ${filename} require calls`)
 
     this.module = new MockedModule(filePath, callerTestRef)
     this.module.load(filePath)
+    Mock.setToCache({ parentFilename, filename, mocks, module: this.module })
   }
 
   static get(parentFilename, filename, mocks) {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -6,7 +6,7 @@ class Mock {
     this.mocks = mocks
 
     if (!filename || typeof filename !== 'string') {
-      throw new TypeError('filename should be a string')
+      throw new TypeError('t.mock() first argument should be a string')
     }
 
     if (!mocks || typeof mocks !== 'object') {
@@ -14,9 +14,10 @@ class Mock {
 are the same used in ${filename} require calls`)
     }
 
-    const filePath = Module._resolveFilename(filename, module.parent)
+    const callerTestRef = module.parent.parent.parent
+    const filePath = Module._resolveFilename(filename, callerTestRef)
     if (!Module._cache[filePath]) {
-      Module._load(filename, module.parent, false)
+      Module._load(filename, callerTestRef, false)
     }
 
     this.original = Module._cache[filePath]
@@ -35,7 +36,7 @@ are the same used in ${filename} require calls`)
     }
 
     mod.loaded = false
-    mod.load(mod.filename)
+    mod.load(filePath)
     this.module = mod.exports
   }
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -40,11 +40,6 @@ are the same used in ${filename} require calls`)
 
       return __require.call(this, id)
     }
-      // TODO: add tests for it, e.g: require.resolve usage
-    for (const key in __require) {
-        console.log('key: ', key)
-      tapRequireMock[key] = __require[key]
-    }
 
     class MockedModule extends Module {
       require (id) {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,39 +1,48 @@
 const Module = require('module')
 
 class Mock {
-  constructor(id, mocks) {
-    if (!id || typeof id !== 'string') {
-      throw new TypeError('invalid mock filepath')
+  constructor(filename, mocks) {
+    this.filename = filename
+    this.mocks = mocks
+
+    if (!filename || typeof filename !== 'string') {
+      throw new TypeError('filename should be a string')
     }
 
-    const filePath = Module._resolveFilename(id, module.parent)
+    if (!mocks || typeof mocks !== 'object') {
+      throw new TypeError(`mocks should be a a key/value object in which keys
+are the same used in ${filename} require calls`)
+    }
+
+    const filePath = Module._resolveFilename(filename, module.parent)
     if (!Module._cache[filePath]) {
-      Module._load(id, module.parent, false)
+      Module._load(filename, module.parent, false)
     }
 
-    const mod = Module._cache[filePath]
-    const originalExports = mod.exports
-    const originalRequire = mod.require
-    mod.require = function (id) {
-      for (const mockKey of Object.keys(mocks)) {
-        return mocks[mockKey]
-      }
+    this.original = Module._cache[filePath]
+    const originalRequire = this.original.require
+
+    const mod = Object.assign(
+      Object.create(Module.prototype),
+      this.original
+    )
+
+    mod.require = function requireMock(id) {
+      if (Object.prototype.hasOwnProperty.call(mocks, id))
+        return mocks[id]
 
       return originalRequire.call(this, id)
     }
 
     mod.loaded = false
     mod.load(mod.filename)
-    const mocked = mod.exports
-    mod.require = originalRequire
-    mod.exports = originalExports
-    return mocked
+    this.module = mod.exports
   }
 
-  static make (id, mocks = {}) {
+  static get(filename, mocks) {
+    const mock = new Mock(filename, mocks)
+    return mock.module
   }
 }
-
-Mock.cache = {}
 
 module.exports = Mock

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,4 +1,5 @@
 const Module = require('module')
+const { isAbsolute } = require('path')
 
 class Mock {
   constructor(parentFilename, filename, mocks = {}) {
@@ -34,6 +35,15 @@ are the same used in ${filename} require calls`)
 
         if (self.mocks.has(requiredFilePath))
           return self.mocks.get(requiredFilePath)
+
+        const isWindows = process.platform === 'win32';
+        const isRelative = id.startsWith('./') ||
+          id.startsWith('../') ||
+          ((isWindows && id.startsWith('.\\')) ||
+          id.startsWith('..\\'))
+
+        if (!isRelative && !isAbsolute(id))
+          return super.require(id)
 
         const unmockedModule = new MockedModule(requiredFilePath, this)
         unmockedModule.load(requiredFilePath)

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,0 +1,39 @@
+const Module = require('module')
+
+class Mock {
+  constructor(id, mocks) {
+    if (!id || typeof id !== 'string') {
+      throw new TypeError('invalid mock filepath')
+    }
+
+    const filePath = Module._resolveFilename(id, module.parent)
+    if (!Module._cache[filePath]) {
+      Module._load(id, module.parent, false)
+    }
+
+    const mod = Module._cache[filePath]
+    const originalExports = mod.exports
+    const originalRequire = mod.require
+    mod.require = function (id) {
+      for (const mockKey of Object.keys(mocks)) {
+        return mocks[mockKey]
+      }
+
+      return originalRequire.call(this, id)
+    }
+
+    mod.loaded = false
+    mod.load(mod.filename)
+    const mocked = mod.exports
+    mod.require = originalRequire
+    mod.exports = originalExports
+    return mocked
+  }
+
+  static make (id, mocks = {}) {
+  }
+}
+
+Mock.cache = {}
+
+module.exports = Mock

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,6 +1,11 @@
 const Module = require('module')
 const { isAbsolute } = require('path')
 
+const isPlainObject = obj => obj
+  && typeof obj === 'object'
+  && (Object.getPrototypeOf(obj) === null
+    || Object.getPrototypeOf(obj) === Object.prototype)
+
 class Mock {
   constructor(parentFilename, filename, mocks = {}) {
     this.filename = filename
@@ -14,7 +19,7 @@ class Mock {
       throw new TypeError('t.mock() first argument should be a string')
     }
 
-    if (typeof mocks !== 'object') {
+    if (!isPlainObject(mocks)) {
       throw new TypeError(`mocks should be a a key/value object in which keys
 are the same used in ${filename} require calls`)
     }

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,25 +1,6 @@
 const Module = require('module')
 
-const getKey = (a, b, c) =>
-  `${a}${b}${
-    JSON.stringify(c, (_, val) => typeof val !== 'object' ? String(val) : val)
-  }`
-
 class Mock {
-  static cache () {
-    if (!this._cache)
-      this._cache = new Map()
-    return this._cache
-  }
-
-  static setToCache({ parentFilename, filename, mocks, module }) {
-    this.cache().set(getKey(parentFilename, filename, mocks), module)
-  }
-
-  static getFromCache({ parentFilename, filename, mocks }) {
-    return this.cache().get(getKey(parentFilename, filename, mocks))
-  }
-
   constructor(parentFilename, filename, mocks = {}) {
     this.filename = filename
     this.mocks = new Map()
@@ -35,12 +16,6 @@ class Mock {
     if (typeof mocks !== 'object') {
       throw new TypeError(`mocks should be a a key/value object in which keys
 are the same used in ${filename} require calls`)
-    }
-
-    const cached = Mock.getFromCache({ parentFilename, filename, mocks })
-    if (cached) {
-      this.module = cached
-      return
     }
 
     const self = this
@@ -73,7 +48,6 @@ are the same used in ${filename} require calls`)
 
     this.module = new MockedModule(filePath, callerTestRef)
     this.module.load(filePath)
-    Mock.setToCache({ parentFilename, filename, mocks, module: this.module })
   }
 
   static get(parentFilename, filename, mocks) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -31,6 +31,7 @@ const path = require('path')
 const fs = require('fs')
 const rimraf = require('rimraf')
 const Fixture = require('./fixture.js')
+const Mock = require('./mock.js')
 const cleanYamlObject = require('./clean-yaml-object.js')
 
 const extraFromError = require('./extra-from-error.js')
@@ -1279,6 +1280,10 @@ class Test extends Base {
 
   fixture (type, content) {
     return new Fixture(type, content)
+  }
+
+  mock (filename, mocks) {
+    return Mock.get(filename, mocks)
   }
 
   matchSnapshot (found, message, extra) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -1282,8 +1282,10 @@ class Test extends Base {
     return new Fixture(type, content)
   }
 
-  mock (filename, mocks) {
-    return Mock.get(filename, mocks)
+  mock (module, mocks) {
+    const {file} = stack.at(Test.prototype.mock)
+    const resolved = path.resolve(file)
+    return Mock.get(resolved, module, mocks)
   }
 
   matchSnapshot (found, message, extra) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -85,10 +85,13 @@ t.test('mock', t => {
     'f.cjs': `module.exports = function () { return 'f' }`,
     'g.js': `module.exports = function () { return 'g' }`,
     'h.js': `module.exports = require.resolve('./g.js')`,
+    'i.js': `module.exports = require('./j.js') + require('./k.js')`,
+    'j.js': `module.exports = require('./k.js')`,
+    'k.js': `module.exports = 'k'`,
   })
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'lib/a.js'), {
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
       [resolve(path, 'lib/b.js')]: () => 'foo',
     })(),
     '{} lorem foo c d e f g',
@@ -102,7 +105,7 @@ t.test('mock', t => {
   )
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'lib/a.js'), {
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
       [resolve(path, 'helpers/d.js')]: () => 'bar',
     })(),
     '{} lorem b c bar f g',
@@ -110,7 +113,7 @@ t.test('mock', t => {
   )
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'lib/a.js'), {
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
       [resolve(path, 'f.cjs')]: () => 'bar',
     })(),
     '{} lorem b c d e bar g',
@@ -118,7 +121,7 @@ t.test('mock', t => {
   )
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'lib/a.js'), {
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
       [resolve(path, 'lib/b.js')]: () => 'foo',
       [resolve(path, 'lib/utils/c')]: () => 'bar',
     })(),
@@ -127,7 +130,7 @@ t.test('mock', t => {
   )
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'lib/a.js'), {
+    Mock.get(__filename, resolve(path, 'lib/a.js'), {
       util: { inspect: obj => obj.constructor.prototype },
     })(),
     '[object Object] lorem b c d e f g',
@@ -141,16 +144,22 @@ t.test('mock', t => {
   )
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'h.js')),
+    Mock.get(__filename, resolve(path, 'h.js')),
     resolve(path, 'g.js'),
     'should preserve require properties and methods',
+  )
+
+  t.equal(
+    Mock.get(__filename, resolve(path, 'i.js')),
+    'kk',
+    'should read non-mocked cached modules from t.mock realm',
   )
 
   // lorem is an unknown module id in the context of the current script,
   // trying to mock it will result in an error while trying to resolve
   // the filename for generating the mocks map
   t.throws(
-    () => Mock.get(resolve(__filename), resolve(path, 'lib/a.js'), {
+    () => Mock.get(__filename, resolve(path, 'lib/a.js'), {
       lorem: () => '***',
     })(),
     { code: 'MODULE_NOT_FOUND' },

--- a/test/mock.js
+++ b/test/mock.js
@@ -9,13 +9,43 @@ t.throws(
 )
 
 t.throws(
-  () => Mock.get(resolve(__filename)),
+  () => Mock.get(__filename),
   /first argument should be a string/,
   'should throw on invalid filename',
 )
 
 t.throws(
-  () => Mock.get(resolve(__filename), './foo.js', ''),
+  () => Mock.get(__filename, './foo.js', ''),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', [1]),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', null),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', /foo/),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', 1),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object',
+)
+
+t.throws(
+  () => Mock.get(__filename, './foo.js', new Map()),
   /mocks should be a a key\/value object in which keys/,
   'should throw on invalid mock-defining object',
 )

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,0 +1,88 @@
+const { resolve } = require('path')
+const t = require('../')
+const Mock = require('../lib/mock.js')
+
+t.throws(
+  () => Mock.get(),
+  /filename should be a string/,
+  'should throw on invalid filename'
+)
+
+t.throws(
+  () => Mock.get('./foo.js'),
+  /mocks should be a a key\/value object in which keys/,
+  'should throw on invalid mock-defining object'
+)
+
+t.test('mock', t => {
+  const path = t.testdir({
+    node_modules: {
+      lorem: {
+        'package.json': JSON.stringify({ name: 'lorem' }),
+        'index.js': `module.exports = function () { return 'lorem' }`,
+      }
+    },
+    lib: {
+      'a.js': `
+const { inspect } = require('util');
+const lorem = require('lorem');
+const b = require('./b.js');
+const c = require('./utils/c');
+module.exports = function() {
+  return [inspect, lorem, b, c].map(i => i({})).join(' ')
+};
+`,
+      'b.js': `module.exports = function () { return 'b' }`,
+      utils: {
+        'c.js': `module.exports = function () { return 'c' }`
+      },
+    }
+  })
+
+  t.equal(
+    Mock.get(resolve(path, 'lib/a.js'), {
+      './b.js': () => 'foo',
+    })(),
+    '{} lorem foo c',
+    'should use injected version of a mock'
+  )
+
+  t.equal(
+    require(resolve(path, 'lib/a.js'))(),
+    '{} lorem b c',
+    'should use original module when requiring prior to mocking'
+  )
+
+  t.equal(
+    Mock.get(resolve(path, 'lib/a.js'), {
+      './b.js': () => 'foo',
+      './utils/c': () => 'bar',
+    })(),
+    '{} lorem foo bar',
+    'should mock nested module'
+  )
+
+  t.equal(
+    Mock.get(resolve(path, 'lib/a.js'), {
+      'lorem': () => '***',
+    })(),
+    '{} *** b c',
+    'should mock node_modules package'
+  )
+
+  t.equal(
+    Mock.get(resolve(path, 'lib/a.js'), {
+      'util': { inspect: obj => obj.constructor.prototype },
+    })(),
+    '[object Object] lorem b c',
+    'should mock builtin module'
+  )
+
+  t.equal(
+    require(resolve(path, 'lib/a.js'))(),
+    '{} lorem b c',
+    'should preserve original module after mocking'
+  )
+
+  t.end()
+})

--- a/test/mock.js
+++ b/test/mock.js
@@ -15,7 +15,7 @@ t.throws(
 )
 
 t.throws(
-  () => Mock.get(resolve(__filename), './foo.js'),
+  () => Mock.get(resolve(__filename), './foo.js', ''),
   /mocks should be a a key\/value object in which keys/,
   'should throw on invalid mock-defining object',
 )
@@ -111,7 +111,7 @@ t.test('mock', t => {
   )
 
   t.equal(
-    Mock.get(resolve(__filename), resolve(path, 'h.js'), {}),
+    Mock.get(resolve(__filename), resolve(path, 'h.js')),
     resolve(path, 'g.js'),
     'should preserve require properties and methods',
   )

--- a/test/mock.js
+++ b/test/mock.js
@@ -54,6 +54,7 @@ t.test('mock', t => {
     },
     'f.cjs': `module.exports = function () { return 'f' }`,
     'g.js': `module.exports = function () { return 'g' }`,
+    'h.js': `module.exports = require.resolve('./g.js')`,
   })
 
   t.equal(
@@ -107,6 +108,12 @@ t.test('mock', t => {
     require(resolve(path, 'lib/a.js'))(),
     '{} lorem b c d e f g',
     'should preserve original module after mocking',
+  )
+
+  t.equal(
+    Mock.get(resolve(__filename), resolve(path, 'h.js'), {}),
+    resolve(path, 'g.js'),
+    'should preserve require properties and methods',
   )
 
   // lorem is an unknown module id in the context of the current script,

--- a/test/test.js
+++ b/test/test.js
@@ -1517,5 +1517,31 @@ t.test('require defining mocks', t => {
     )
   })
 
+  t.test('should support mocking builtin modules within nested deps', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js':
+          `module.exports = require('./b.js')`,
+        'b.js':
+          `module.exports = require('./c.js')`,
+        'c.js':
+          `module.exports = () => require('fs')`,
+      },
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mocking builtin modules in nested modules', t => {
+          const fs = {}
+          const a = t.mock('./lib/a.js', { fs })
+          t.equal(a(), fs, 'should get mocked fs result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1488,5 +1488,34 @@ t.test('require defining mocks', t => {
     )
   })
 
+  t.test('should support cicle require', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js':
+          `module.exports = require('./b.js')`,
+        'b.js':
+          `const c = require('./c.js')
+          const b = () => 'b and ' + c
+          b.extra = 'BBB'
+          module.exports = () => 'b and ' + c`,
+        'c.js':
+          `const b = require('./b.js')
+          module.exports = () => 'c and ' + b.extra`,
+      },
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mocking cicled required deps', t => {
+          const a = t.mock('./lib/a.js', {})
+          t.ok('should not explode')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1274,6 +1274,27 @@ t.test('require defining mocks', t => {
     )
   })
 
+  t.test('run-time invoked require call', t => {
+    const f = t.testdir({
+      'a.js': 'module.exports = "a"',
+        'index.js': 'module.exports = () => { return require("./a.js") }',
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mock file at run time', t => {
+          const i = t.mock('./index.js', {
+            './a.js': 'mocked-a',
+          })
+          t.equal(i(), 'mocked-a', 'should get mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
   t.test('nested lib files', t => {
     const f = t.testdir({
       lib: {

--- a/test/test.js
+++ b/test/test.js
@@ -1345,7 +1345,7 @@ t.test('require defining mocks', t => {
             const i = t.mock('../index.js', {
               '../lib/a.js': 'mocked-a',
             })
-            t.equal(i(), 'mocked-a b a b d d', 'should get expected mocked result')
+            t.equal(i(), 'mocked-a b mocked-a b d d', 'should get expected mocked result')
             t.end()
           })
 
@@ -1451,6 +1451,33 @@ t.test('require defining mocks', t => {
             'util': { format: () => 'mocked-util' },
           })
           t.equal(i('bar'), 'mocked-util', 'should get mocked result')
+          t.end()
+        })`,
+    })
+    return t.spawn(
+      process.execPath,
+      [ path.resolve(f, 'test.js') ],
+      { cwd: f },
+    )
+  })
+
+  t.test('should support mocking within nested deps', t => {
+    const f = t.testdir({
+      lib: {
+        'a.js':
+          `module.exports = require('./b.js')`,
+        'b.js':
+          `module.exports = require('./c.js')`,
+        'c.js':
+          `module.exports = () => 'c'`,
+      },
+      'test.js':
+        `const t = require('../..'); // tap
+        t.test('mocking deps of required modules', t => {
+          const a = t.mock('./lib/a.js', {
+            './lib/c.js': () => 'mocked-c',
+          })
+          t.equal(a(), 'mocked-c', 'should get mocked-c result')
           t.end()
         })`,
     })

--- a/test/test.js
+++ b/test/test.js
@@ -1226,13 +1226,19 @@ t.test('save a fixture', t => {
 t.test('require defining mocks', t => {
   const f = t.testdir({
     node_modules: {
-      foo: 'module.exports = { bar: () => "bar" }'
+      foo: 'module.exports = { bar: () => "bar" }',
     },
     'index.js': 'module.exports = require("foo").bar()'
   })
   const myModule = t.mock(path.resolve(f, 'index.js'), {
-    foo: { bar: () => 'lorem' }
+    foo: { bar: () => 'lorem' },
   })
   t.equal(myModule, 'lorem', 'should mock internally required modules')
+
+  const diags = t.mock('../lib/diags.js', {
+    './obj-to-yaml.js': a => `foo ${a}`,
+  })
+  t.equal(diags('bar'), '\nfoo bar', 'should mock actual lib file')
+
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1222,3 +1222,17 @@ t.test('save a fixture', t => {
   t.ok(fs.statSync(leaveDir).isDirectory(), 'left dir behind')
   t.end()
 })
+
+t.test('require defining mocks', t => {
+  const f = t.testdir({
+    node_modules: {
+      foo: 'module.exports = { bar: () => "bar" }'
+    },
+    'index.js': 'module.exports = require("foo").bar()'
+  })
+  const myModule = t.mock(path.resolve(f, 'index.js'), {
+    foo: { bar: () => 'lorem' }
+  })
+  t.equal(myModule, 'lorem', 'should mock internally required modules')
+  t.end()
+})


### PR DESCRIPTION
This brings into **tap** the standard mocking system we have been using across the ecosystem of packages from the npm cli which consists into hijacking the `require` calls from a given module and defining whatever mock we want via something as simple as a key/value object.

It's a very conscious decision to make it a very opinionated API, as stated in https://github.com/tapjs/node-tap#tutti-i-gusti-sono-gusti - focusing only on the pattern that have been the standard way we handle mocks.

It builds on the initial draft work from @nlf (ref: https://gist.github.com/nlf/52ca6adab49e5b3939ba37c7f0fc51c6) and initial brainstorming of such an API with @mikemimik - thanks ❤️ 

### Example

```js
t.test('testing something, t => {
  const myModule = t.mock('../my-module.js', {
    fs: { readFileSync: () => 'foo' }
  })

  t.equal(myModule.bar(), 'foo', 'should receive expected content')
})
```