### PR TITLE
allow junctions

### DIFF
--- a/docs/src/content/docs/api/fixtures/index.md
+++ b/docs/src/content/docs/api/fixtures/index.md
@@ -55,12 +55,14 @@ finished.
 
 ## Fixture Arguments
 
-The [`t.fixture(type, content)`](/docs/api/#tfixturetype-content) method
+The [`t.fixture(type, content, extra)`](/docs/api/#tfixturetype-content-extra) method
 will create a `Fixture` object with the specified type and content.  The
 supported types are:
 
 * `link` - A hardlink to the file specified in `content`.
-* `symlink` - A symbolic link to the path specified in `content`.
+* `symlink` - A symbolic link to the path specified in `content`. The `extra`
+  parameter is passed to `fs.symlinkSync` and allows for creating junctions
+  in Windows.
 * `dir` - A directory, where the `content` is an object describing the
   children in that directory.
 * `file` - A file, where the `content` is the file contents.

--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -205,7 +205,7 @@ test teardown.  Returns the directory name.
 
 See [testing with fixtures](/docs/api/fixtures/) for more info.
 
-### t.fixture(type, content)
+### t.fixture(type, content, extra)
 
 Create a `fixture` object, to specify hard links and symbolic links in the
 fixture definition object passed to `t.testdir()`.

--- a/lib/fixture.js
+++ b/lib/fixture.js
@@ -3,9 +3,10 @@ const {resolve, dirname} = require('path')
 const mkdirp = require('mkdirp')
 
 class Fixture {
-  constructor (type, content) {
+  constructor (type, content, extra) {
     this.type = type
     this.content = content
+    this.extra = extra
     switch (type) {
       case 'dir':
         if (!content || typeof content !== 'object')
@@ -39,7 +40,7 @@ class Fixture {
 
     switch (f.type) {
       case 'symlink':
-        symlinkSync(f.content, abs)
+        symlinkSync(f.content, abs, f.extra)
         break
       case 'link':
         linkSync(resolve(dirname(abs), f.content), abs)

--- a/lib/test.js
+++ b/lib/test.js
@@ -1277,8 +1277,8 @@ class Test extends Base {
     return dir
   }
 
-  fixture (type, content) {
-    return new Fixture(type, content)
+  fixture (type, content, extra) {
+    return new Fixture(type, content, extra)
   }
 
   matchSnapshot (found, message, extra) {

--- a/test/run/coverage.js
+++ b/test/run/coverage.js
@@ -36,7 +36,7 @@ const t3 = tmpfile(t, '3.test.js', `'use strict'
 const escapePath = `${path.dirname(process.execPath)}:${process.env.PATH}`
 const esc = tmpfile(t, 'runtest.sh',
 `#!/bin/bash
-export PATH=${escapePath}
+export PATH="${escapePath}"
 "${node}" "${bin}" "\$@" \\
   --cov \\
   --nyc-arg=--temp-dir="${dir}/.nyc_output" \\

--- a/test/run/watermarks.js
+++ b/test/run/watermarks.js
@@ -17,7 +17,7 @@ t.cleanSnapshot = str => clean(str).replace(/[0-9\.]+m?s/g, '{TIME}')
 const escapePath = `${dirname(process.execPath)}:${process.env.PATH}`
 const esc = tmpfile(t, 'runtest.sh',
 `#!/bin/bash
-export PATH=${escapePath}
+export PATH="${escapePath}"
 "${node}" "${bin}" "\$@" \\
   --cov \\
   --nyc-arg=--temp-dir="${dir}/.nyc_output" \\


### PR DESCRIPTION
in Windows, admin privileges are required in order to create symlinks, however junctions can be created by regular users.

i didn't want to make symlinks always be junctions (the third parameter to `symlink{,Sync}` is ignored everywhere but Windows) however because a junction cannot point to a file. that left three options:

1. allow the user to pass their own third parameter to `symlink{,Sync}`
2. try to intelligently determine if the target is a file or directory, default directories to junctions and files to symlinks
3. add a new `'junction'` type to `t.fixture()` such that users who want windows compatibility can use that instead of `'symlink'`

for now i went with option 1, but i'm open to reworking this pull request for option 3 if that makes more sense