### PR TITLE
Include tap.mjs in the released bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "bin/run.js",
     "bin/jsx.js",
     "bin/jack.js",
-    "lib/*.js"
+    "lib/*.js",
+    "lib/*.mjs"
   ],
   "bundleDependencies": [
     "ink",


### PR DESCRIPTION
The `lib/tap.mjs` file is not present in the bundle, making tap unloadable in native esm.