### PR TITLE
Rename t.notEqual to t.not.

### DIFF
--- a/docs/src/content/docs/api/asserts/index.md
+++ b/docs/src/content/docs/api/asserts/index.md
@@ -194,7 +194,7 @@ the object that is wanted.
 Synonyms: `t.equals`, `t.isEqual`, `t.is`, `t.strictEqual`,
 `t.strictEquals`, `t.strictIs`, `t.isStrict`, `t.isStrictly`
 
-## t.notEqual(found, notWanted, message, extra)
+## t.not(found, notWanted, message, extra)
 
 Inverse of `t.equal()`.
 


### PR DESCRIPTION
t.notEqual is a synonym, and as of tap15 it appears all synonyms are deprecated. Given that this is the primary identifier, this makes sense as a documentation change.