### PR TITLE
Remove unused import

### DIFF
--- a/bin/jack.js
+++ b/bin/jack.js
@@ -1,7 +1,6 @@
 const { jack, num, opt, list, flag, env } = require('jackspeak')
 
 const {cpus} = require('os')
-const colorSupport = require('color-support')
 
 const reporters = [...new Set([
   ...(require('tap-mocha-reporter').types),


### PR DESCRIPTION
This is to solve issue #743. The issue actually only happens when a project has an `.npmrc` with `legacy-bundling=true` set. This causes `bin/jack.js` to not find the dependency because it hasn't been flattened out to the top-level of `node_modules`. As far as I know, it's effectively impossible to write a test for this case. However, the dependency is completely unused in the `bin/jack.js` code, so the fix is simple: remove the import.