### PR TITLE
Support Typescript for lifecycle events

### DIFF
--- a/tap-snapshots/test/run/ts.js.test.cjs
+++ b/tap-snapshots/test/run/ts.js.test.cjs
@@ -24,6 +24,67 @@ ok 2 - cli-tests/mixed/foo.ts # {time} {
 
 `
 
+exports[`test/run/ts.js TAP via cli args ts --after --before ok > must match snapshot 1`] = `
+setup
+TAP version 13
+ok 1 - cli-tests/ts/ok.ts # {time} {
+    ok 1 - this is ok
+    1..1
+    # {time}
+}
+
+1..1
+# {time}
+teardown
+
+`
+
+exports[`test/run/ts.js TAP via cli args ts --after fail > stderr 1`] = `
+
+{CWD}/cli-tests/ts/teardown.ts:2
+      throw new Error('fail')
+            ^
+Error: fail
+    {STACK}
+
+# failed cli-tests/ts/teardown.ts
+# code=1 signal=null
+
+
+`
+
+exports[`test/run/ts.js TAP via cli args ts --after fail > stdout 1`] = `
+setup
+TAP version 13
+ok 1 - cli-tests/ts/ok.ts # {time} {
+    ok 1 - this is ok
+    1..1
+    # {time}
+}
+
+1..1
+# {time}
+
+`
+
+exports[`test/run/ts.js TAP via cli args ts --before fail > stderr 1`] = `
+
+{CWD}/cli-tests/ts/setup.ts:2
+      throw new Error('fail')
+            ^
+Error: fail
+    {STACK}
+
+# failed cli-tests/ts/setup.ts
+# code=1 signal=null
+
+
+`
+
+exports[`test/run/ts.js TAP via cli args ts --before fail > stdout 1`] = `
+
+`
+
 exports[`test/run/ts.js TAP via cli args ts > must match snapshot 1`] = `
 TAP version 13
 ok 1 - cli-tests/ts/ok.ts # {time} {

--- a/test/run/ts.js
+++ b/test/run/ts.js
@@ -111,6 +111,62 @@ t.test('via cli args', t => {
     })
   })
 
+  t.test('ts --after --before ok', t => {
+    const ok = tmpfile(t, 'ts/ok.ts', `
+      import * as t from ${tap}
+      t.pass('this is ok')
+    `)
+    const before = tmpfile(t, 'ts/setup.ts', `
+      console.log('setup')
+    `)
+    const after = tmpfile(t, 'ts/teardown.ts', `
+      console.log('teardown')
+    `)
+    run([ok, `--before=${before}`, `--after=${after}`, '--ts'], {}, (er, o) => {
+      t.equal(er, null)
+      t.matchSnapshot(o)
+      t.end()
+    })
+  })
+
+  t.test('ts --before fail', t => {
+    const ok = tmpfile(t, 'ts/ok.ts', `
+      import * as t from ${tap}
+      t.pass('this is ok')
+    `)
+    const before = tmpfile(t, 'ts/setup.ts', `
+      throw new Error('fail')
+    `)
+    const after = tmpfile(t, 'ts/teardown.ts', `
+      console.log('teardown')
+    `)
+    run([ok, `--before=${before}`, `--after=${after}`, '--ts'], {}, (er, o, e) => {
+      t.not(er, null)
+      t.matchSnapshot(o, 'stdout')
+      t.matchSnapshot(e, 'stderr')
+      t.end()
+    })
+  })
+
+  t.test('ts --after fail', t => {
+    const ok = tmpfile(t, 'ts/ok.ts', `
+      import * as t from ${tap}
+      t.pass('this is ok')
+    `)
+    const before = tmpfile(t, 'ts/setup.ts', `
+      console.log('setup')
+    `)
+    const after = tmpfile(t, 'ts/teardown.ts', `
+      throw new Error('fail')
+    `)
+    run([ok, `--before=${before}`, `--after=${after}`, '--ts'], {}, (er, o, e) => {
+      t.not(er, null)
+      t.matchSnapshot(o, 'stdout')
+      t.matchSnapshot(e, 'stderr')
+      t.end()
+    })
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
# What is in PR

 - Allow to use Typescript files in lifecycle events: `--before` and `--after`
 - Fix #690 

```
Example:

tap --ts --before=test/setup.ts --after=test/teardown.ts
```