### PR TITLE
docs: don't claim ts-node is bundled

### DIFF
--- a/bin/jack.js
+++ b/bin/jack.js
@@ -604,7 +604,8 @@ Much more documentation available at: https://www.node-tap.org/
   ts: flag({
     default: process.env.TAP_TS === '1',
     description: `Automatically compile .ts and .tsx tests using the
-                  ts-node module (Default: false)`,
+                  ts-node module, which you will need to install separately
+                  (Default: false)`,
   }),
 
   jsx: flag({

--- a/bin/jack.js
+++ b/bin/jack.js
@@ -603,7 +603,7 @@ Much more documentation available at: https://www.node-tap.org/
 
   ts: flag({
     default: process.env.TAP_TS === '1',
-    description: `Automatically load .ts and .tsx tests with tap's bundled
+    description: `Automatically compile .ts and .tsx tests using the
                   ts-node module (Default: false)`,
   }),
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -376,7 +376,8 @@ Other Options:
   --no-flow              switch off the --flow flag
 
   --ts                   Automatically compile .ts and .tsx tests using the
-                         ts-node module (Default: false)
+                         ts-node module, which you will need to install
+                         separately (Default: false)
 
   --no-ts                switch off the --ts flag
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -375,8 +375,8 @@ Other Options:
   --flow                 Removes flow types
   --no-flow              switch off the --flow flag
 
-  --ts                   Automatically load .ts and .tsx tests with tap's
-                         bundled ts-node module (Default: false)
+  --ts                   Automatically compile .ts and .tsx tests using the
+                         ts-node module (Default: false)
 
   --no-ts                switch off the --ts flag
 


### PR DESCRIPTION
A docs-only change. `ts-node` isn't bundled any more, so don't claim that it is.