### PR TITLE
Fix script on using node-tap with codecov

### DIFF
--- a/docs/src/content/docs/coverage/index.md
+++ b/docs/src/content/docs/coverage/index.md
@@ -77,7 +77,7 @@ following:
     {
       "scripts": {
         "test": "tap",
-        "posttest": "tap --coverage-report=text-lcov | codecov"
+        "posttest": "tap --coverage-report=text-lcov | codecov --pipe"
       }
     }
     ```


### PR DESCRIPTION
I followed existing instruction on how to use node-tap with CodeCov, but it doesn't work. I got [X Failed to read file at ](https://github.com/tsekityam/nyse-holidays/runs/3241973533?check_suite_focus=true#step:6:111) from CodeCov.

After some investigation, I found that `--pipe` is required by `codecov` to read from pipe.

I [added](https://github.com/tsekityam/nyse-holidays/commit/04332b0cd91004ed21772885500af132e3b3cdaa) that to my repo, and the coverage report was [uploaded](https://github.com/tsekityam/nyse-holidays/runs/3242078792?check_suite_focus=true#step:6:110) to CodeCov successfully