### PR TITLE
feat(cli): remove validation for --coverage-report

### DIFF
--- a/bin/jack.js
+++ b/bin/jack.js
@@ -376,7 +376,6 @@ Much more documentation available at: https://www.node-tap.org/
 
   'coverage-report': list({
     hint: 'type',
-    valid: nycReporters,
     description: `Output coverage information using the
                   specified istanbul/nyc reporter type.
 
@@ -390,7 +389,7 @@ Much more documentation available at: https://www.node-tap.org/
                   This can be run on its own at any time
                   after a test run that included coverage.
 
-                  Available NYC reporters:
+                  Built-in NYC reporters:
                   ${nycReporters.join(' ')}`,
   }),
 


### PR DESCRIPTION
this allows for custom nyc coverage report packages to be used.

reference: https://github.com/istanbuljs/nyc#common-configuration-options

> `reporter`: May be set to a built-in coverage reporter or an npm package (dev)dependency



