### PR TITLE
expose tap/mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "default": "./lib/tap.js"
     },
     "./*": "./*",
-    "./": "./"
+    "./": "./",
+    "./mocha": "./lib/mocha.js"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
Much like #818, I'm also migrating and wanted a clean import e.g.

`import { describe, it } from 'tap/mocha'`