### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,24 @@ on:
       - 'docs/**'
       - 'docs-content/**'
       - '*.md'
+permissions:
+  contents: read
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.0.x, 16.x, 17.x]
-        os: [ubuntu-latest]
+        node-version: [14.0.x, 14.x, 16.0.x, 16.x, 18.0.x, 18.x, 19.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.0.x, 14.x, 16.0.x, 16.x, 18.0.x, 18.x, 19.x]
+        node-version: [12.0.x, 12.x, 14.0.x, 14.x, 16.0.x, 16.x, 18.0.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/isaacs-makework.yml
+++ b/.github/workflows/isaacs-makework.yml
@@ -10,11 +10,11 @@ jobs:
   makework:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Use Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: put repo in package.json


### PR DESCRIPTION
dropping node 12 testing, as it is EOL
update actions to fix deprecation notices in workflow runs
adding node 19 testing