### PR TITLE
move bundled dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,11 @@
       ],
       "license": "ISC",
       "dependencies": {
-        "@isaacs/import-jsx": "^4.0.1",
-        "@types/react": "^17",
         "chokidar": "^3.3.0",
         "findit": "^2.0.0",
         "foreground-child": "^2.0.0",
         "fs-exists-cached": "^1.0.0",
         "glob": "^7.1.6",
-        "ink": "^3.2.0",
         "isexe": "^2.0.0",
         "istanbul-lib-processinfo": "^2.0.2",
         "jackspeak": "^1.4.1",
@@ -32,7 +29,6 @@
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.1",
-        "react": "^17.0.2",
         "rimraf": "^3.0.0",
         "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
@@ -40,18 +36,22 @@
         "tap-parser": "^11.0.1",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.7",
-        "treport": "^3.0.3",
         "which": "^2.0.2"
       },
       "bin": {
         "tap": "bin/run.js"
       },
       "devDependencies": {
+        "@isaacs/import-jsx": "^4.0.1",
+        "@types/react": "^17",
         "coveralls": "^3.1.1",
         "eslint": "^7.25.0",
         "flow-remove-types": "^2.112.0",
+        "ink": "^3.2.0",
         "node-preload": "^0.2.1",
         "process-on-spawn": "^1.0.0",
+        "react": "^17.0.2",
+        "treport": "^3.0.3",
         "ts-node": "^8.5.2",
         "typescript": "^3.7.2"
       },
@@ -178,6 +178,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
       "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -273,6 +274,7 @@
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
       "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=6.9.0"
@@ -373,6 +375,7 @@
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.2.tgz",
       "integrity": "sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/compat-data": "^7.20.1",
@@ -392,6 +395,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
       "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -407,6 +411,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -419,6 +424,7 @@
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.2.tgz",
       "integrity": "sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -434,6 +440,7 @@
       "version": "7.20.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.3.tgz",
       "integrity": "sha512-oZg/Fpx0YDrj13KsLyO8I/CX3Zdw7z0O9qOd95SqcoIzuqy/WTGWvePeHAnZCN54SfdyjHcb1S30gc8zlzlHcA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -449,6 +456,7 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
       "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -584,6 +592,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/import-jsx/-/import-jsx-4.0.1.tgz",
       "integrity": "sha512-l34FEsEqpdYdGcQjRCxWy+7rHY6euUbOBz9FI+Mq6oQeVhNegHcXFSJxVxrJvOpO31NbnDjS74quKXDlPDearA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@babel/core": "^7.5.5",
@@ -682,12 +691,14 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/@types/react": {
       "version": "17.0.52",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
       "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -699,12 +710,14 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/@types/yoga-layout": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
       "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/acorn": {
@@ -769,6 +782,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -784,6 +798,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=10"
@@ -817,6 +832,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/anymatch": {
@@ -883,6 +899,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=8"
@@ -906,6 +923,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
       "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=8"
@@ -1032,6 +1050,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-4.1.0.tgz",
       "integrity": "sha512-99nnnGlJexTc41xwQTr+mWl15OI5PPczUJzM4YRE7QjkefMKCXGa5gfQjCOuVrD+1TjI/fevIDHg2nz3iYN5Ig==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "callsites": "^3.1.0"
@@ -1044,6 +1063,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-3.0.1.tgz",
       "integrity": "sha512-fhmztL4wURO/BzwJUJ4aVRdnKEFskPBbrJ8fNgl7XdUiD1ygzzlt+nhPgUBSRq2ciEVubo6x+W8vJQzm55QLLQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "caller-callsite": "^4.1.0"
@@ -1056,6 +1076,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=6"
@@ -1089,6 +1110,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
@@ -1148,6 +1170,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/clean-stack": {
@@ -1162,6 +1185,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=6"
@@ -1174,6 +1198,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -1186,6 +1211,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
       "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "slice-ansi": "^3.0.0",
@@ -1258,6 +1284,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
       "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "convert-to-spaces": "^1.0.1"
@@ -1323,6 +1350,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
       "integrity": "sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">= 4"
@@ -1370,6 +1398,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/dashdash": {
@@ -2304,6 +2333,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ink/-/ink-3.2.0.tgz",
       "integrity": "sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -2347,6 +2377,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2362,6 +2393,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2378,6 +2410,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2390,12 +2423,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/ink/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=8"
@@ -2405,6 +2440,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2428,6 +2464,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "ci-info": "^2.0.0"
@@ -2775,6 +2812,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/lodash.flattendeep": {
@@ -2807,6 +2845,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -2873,6 +2912,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=6"
@@ -3029,6 +3069,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3047,6 +3088,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -3173,6 +3215,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-1.0.0.tgz",
       "integrity": "sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=10"
@@ -3308,6 +3351,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -3321,6 +3365,7 @@
       "version": "4.26.1",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.26.1.tgz",
       "integrity": "sha512-r1csa5n9nABVpSdAadwTG7K+SfgRJPc/Hdx89BkV5IlA1mEGgGi3ir630ST5D/xYlJQaY3VE75YGADgpNW7HIw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -3331,6 +3376,7 @@
       "version": "0.26.2",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz",
       "integrity": "sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -3359,6 +3405,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "esprima": "~4.0.0"
@@ -3455,6 +3502,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=4"
@@ -3464,6 +3512,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "onetime": "^5.1.0",
@@ -3518,6 +3567,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -3561,6 +3611,7 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
       "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true,
       "inBundle": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3576,6 +3627,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
       "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3590,6 +3642,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3605,6 +3658,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3617,6 +3671,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/source-map": {
@@ -3971,6 +4026,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/treport/-/treport-3.0.4.tgz",
       "integrity": "sha512-zUw1sfJypuoZi0I54woo6CNsfvMrv+OwLBD0/wc4LhMW8MA0MbSE+4fNObn22JSR8x9lOYccuAzfBfZ2IemzoQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@isaacs/import-jsx": "^4.0.1",
@@ -3990,6 +4046,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4005,6 +4062,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4018,6 +4076,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4030,12 +4089,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "inBundle": true
     },
     "node_modules/treport/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=8"
@@ -4045,6 +4106,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4117,6 +4179,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
       "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=10"
@@ -4247,6 +4310,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "string-width": "^4.0.0"
@@ -4332,6 +4396,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
       "inBundle": true,
       "engines": {
         "node": ">=8.3.0"
@@ -4425,6 +4490,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz",
       "integrity": "sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==",
+      "dev": true,
       "inBundle": true,
       "dependencies": {
         "@types/yoga-layout": "1.9.2"

--- a/package.json
+++ b/package.json
@@ -21,14 +21,11 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@isaacs/import-jsx": "^4.0.1",
-    "@types/react": "^17",
     "chokidar": "^3.3.0",
     "findit": "^2.0.0",
     "foreground-child": "^2.0.0",
     "fs-exists-cached": "^1.0.0",
     "glob": "^7.1.6",
-    "ink": "^3.2.0",
     "isexe": "^2.0.0",
     "istanbul-lib-processinfo": "^2.0.2",
     "jackspeak": "^1.4.1",
@@ -37,7 +34,6 @@
     "mkdirp": "^1.0.4",
     "nyc": "^15.1.0",
     "opener": "^1.5.1",
-    "react": "^17.0.2",
     "rimraf": "^3.0.0",
     "signal-exit": "^3.0.6",
     "source-map-support": "^0.5.16",
@@ -45,16 +41,20 @@
     "tap-parser": "^11.0.1",
     "tap-yaml": "^1.0.0",
     "tcompare": "^5.0.7",
-    "treport": "^3.0.3",
     "which": "^2.0.2"
   },
   "devDependencies": {
+    "@isaacs/import-jsx": "^4.0.1",
+    "@types/react": "^17",
     "coveralls": "^3.1.1",
     "eslint": "^7.25.0",
     "flow-remove-types": "^2.112.0",
+    "ink": "^3.2.0",
     "node-preload": "^0.2.1",
     "process-on-spawn": "^1.0.0",
+    "react": "^17.0.2",
     "ts-node": "^8.5.2",
+    "treport": "^3.0.3",
     "typescript": "^3.7.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
I assume that the current windows issues are a result of the bundling of the dependencies. So maybe to resolve this issue, we need to move the dependencies which are anyway bundled into devDepencencies.

I dont know how to test this assumption