### PR TITLE
docs: remove unused title

### DIFF
--- a/docs/src/content/docs/api/asserts/index.md
+++ b/docs/src/content/docs/api/asserts/index.md
@@ -315,8 +315,6 @@ prototype chain.
 names, and `found` can be any value other than `null` or `undefined`
 (though of course `false` and `true` have no ownProperties).
 
-## t.has
-
 ## t.match(found, pattern, message, extra)
 
 Verify that the found object matches the pattern provided.


### PR DESCRIPTION
Hi, just remove the unused title into the asserts documentation.