### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -280,7 +280,7 @@ Note that all assert methods also return `true` if they pass.
 
 Print the supplied message as a TAP comment.
 
-If you provide the `--comment` flag to the test runner, then tap
+If you provide the `--comments` flag to the test runner, then tap
 comments will be printed to stderr.
 
 Note that you can always use `console.error()` for debugging (or


### PR DESCRIPTION
The CLI option to print out comments should be `--comments` instead of `--comment`.