### PR TITLE
fix(config): update markdown help for --include

### DIFF
--- a/src/config/src/jack.ts
+++ b/src/config/src/jack.ts
@@ -605,7 +605,8 @@ export default jack({
                     By default, tap will search for all files ending in these
                     known file type extensions in the following ways:
 
-                    - a top-level folder named test, tests, or __tests__
+                    - a top-level folder named \`test\`, \`tests\`, or
+                      \`__tests__\`
                     - any file ending in \`.spec.\` or \`.test.\` before a
                       supported extension, or
                     - a top-level file named \`test.(js,jsx,...)\` or


### PR DESCRIPTION
Fixes a visual bug in the markdown docs for `--include`.

## Before

By default, tap will search for all files ending in these known file type extensions in the following ways:

- a top-level folder named test, tests, or __tests__
- any file ending in `.spec.` or `.test.` before a supported extension, or
- a top-level file named `test.(js,jsx,...)` or `tests.(js,jsx,...)`

## After

By default, tap will search for all files ending in these known file type extensions in the following ways:

- a top-level folder named `test`, `tests`, or `__tests__`
- any file ending in `.spec.` or `.test.` before a supported extension, or
- a top-level file named `test.(js,jsx,...)` or `tests.(js,jsx,...)`
