### PR TITLE
`@tapjs/create-plugin` missing templates

### DIFF
--- a/src/create-plugin/package.json
+++ b/src/create-plugin/package.json
@@ -8,7 +8,8 @@
   },
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "tshy": {
     "dialects": [


### PR DESCRIPTION
```
❯ npm init @tapjs/plugin
Plugin package name: (tap-plugin-wdfg-sksw) test-tap-plugin
Plugin description:
Run npm install? (Yes) no
Run git init? (Yes) no
Folder to create in? (test-tap-plugin)
node:internal/process/esm_loader:97
    internalBinding('errors').triggerUncaughtException(
                              ^

[Error: ENOENT: no such file or directory, scandir '/Users/jason/.npm/_npx/025377bf2cfee723/node_modules/@tapjs/create-plugin/templates'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: '/Users/jason/.npm/_npx/025377bf2cfee723/node_modules/@tapjs/create-plugin/templates'
}```