### PR TITLE
`tap build` failing when adding external plugin.

### DIFF
--- a/src/test/scripts/build.mts
+++ b/src/test/scripts/build.mts
@@ -217,7 +217,7 @@ const pluginNames = (
       return name
     })
   )
-).sort((a, b) => a.localeCompare(b))
+)
 
 const pluginImport = plugins
   .map(


### PR DESCRIPTION
I've been trying to use the new plugin feature, but found that adding even the simplest plugin caused tap build to fail.

I tracked this down to `src/test/scripts/build.mts`, which constructs the imports that go into `test/test-built/src/index.ts` by combining a list of plugin names and a generated list of import variable names:

```
const pluginImport = plugins
  .map(
    (p, i) =>
      `import * as ${pluginNames[i]} from ${JSON.stringify(p)}\n`
  )
  .join('')
```

The problem I was encountering is that when it generates the list of variable names, it sorts them separately from the plugins. So when I tried to add a plugin named `@jasonk/tap`, it ended up generating imports like this:

```
import * as Plugin_after from "@jasonk/tap"
import * as Plugin_afterEach from "@tapjs/after"
import * as Plugin_asserts from "@tapjs/after-each"
import * as Plugin_before from "@tapjs/asserts"
import * as Plugin_beforeEach from "@tapjs/before"
import * as Plugin_filter from "@tapjs/before-each"
import * as Plugin_fixture from "@tapjs/filter"
import * as Plugin_intercept from "@tapjs/fixture"
import * as Plugin_mock from "@tapjs/intercept"
import * as Plugin_snapshot from "@tapjs/mock"
import * as Plugin_spawn from "@tapjs/snapshot"
import * as Plugin_stdin from "@tapjs/spawn"
import * as Plugin_tap from "@tapjs/stdin"
import * as Plugin_typescript from "@tapjs/typescript"
import * as Plugin_worker from "@tapjs/worker"
```

This then causes the generated tests for config values to look for options on the wrong plugins, which caused the errors I was seeing.

Just removing the sort from the code generating `pluginNames` so that it has the same order the original plugin list did appear to solve the problem.