### PR TITLE
avoid running tap from global location, warn if trying to manage plugins with global install

### DIFF
--- a/src/run/tap-snapshots/test/plugin.ts.test.cjs
+++ b/src/run/tap-snapshots/test/plugin.ts.test.cjs
@@ -209,3 +209,33 @@ Array [
   ],
 ]
 `
+
+exports[`test/plugin.ts > TAP > print warning if not running in project > must match snapshot 1`] = `
+Object {
+  "errs": Array [
+    Array [
+      String(
+        global/local mixup!
+        
+        The tap plugin command must be run by the locally installed tap executable,
+        and this appears to be running in a global install location at
+        /global/
+        
+        This will likely fail. Try:
+        
+            npm exec tap plugin "list"
+        
+      ),
+    ],
+  ],
+  "logs": Array [
+    Array [
+      String(
+        a
+        b
+        c
+      ),
+    ],
+  ],
+}
+`

--- a/src/tap/package.json
+++ b/src/tap/package.json
@@ -60,7 +60,8 @@
     "@tapjs/stdin": "1.1.6",
     "@tapjs/test": "1.3.6",
     "@tapjs/typescript": "1.2.6",
-    "@tapjs/worker": "1.1.6"
+    "@tapjs/worker": "1.1.6",
+    "resolve-import": "1.4.2"
   },
   "tap": {
     "typecheck": false,

--- a/src/tap/src/run.mts
+++ b/src/tap/src/run.mts
@@ -4,5 +4,24 @@
  */
 //@ts-ignore
 process.setSourceMapsEnabled(true)
-// just import the runner, it does all the work
-import '@tapjs/run'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// Try to load the tap runner that's installed in the current project,
+// if present. Running plugin builds etc from the global space will
+// never ever work as expected, but people do global installs to be
+// able to run tap without `npm exec` or `npm run-script`,
+// so may as well make it do the right thing.
+
+import { resolveImport } from 'resolve-import'
+// import('@tapjs/run')
+await import(
+  String(
+    await resolveImport(
+      '@tapjs/run',
+      await resolveImport('tap', pathToFileURL(resolve('x'))).catch(
+        () => import.meta.url
+      )
+    )
+  )
+)


### PR DESCRIPTION
Fix #940