### PR TITLE
mock: allow absolute deps, not node builtins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
           TAP_TIMEOUT: '0'
           TAP_COLOR: '1'
         run: |
-          npm test -ws --color=always
+          npm test -ws --color=always -Rmin

--- a/src/docs/content/changelog.md
+++ b/src/docs/content/changelog.md
@@ -21,6 +21,20 @@ property keys being ignored.
   `Symbol.<key>`, eg `Symbol.iterator` instead of
   `Symbol(Symbol.iterator)`.
 - Add `--reporter-file` option to pipe test report to a file.
+- (18.4.1) Print Symbols better in `js` compare/formatting styles
+- (18.4.1) Include known non-enumerable Error properties in
+  comparisons
+- (18.4.1) Pre-load source maps to avoid excessive calls causing
+  hang in Node 20 on exit.
+- (18.4.2) Fix timing issue breaking `node --test` serialization
+- (18.4.3) reporter: fix extra space on source indicator line
+- (18.4.3) Fix some combinations of `async` test functions,
+  `t.plan()`, and explicit `t.end()` resulting in "Test after
+  promise resolution" errors.
+- (18.4.4) snapshot: handle file:// cwd urls on windows
+- (18.4.4) manage plugins better in npm workspaces
+- (18.4.4) mock: allow absolute deps to be mocked, but not node
+  builtins
 
 ## 18.3
 

--- a/src/mock/src/resolve-mock-entry-point.ts
+++ b/src/mock/src/resolve-mock-entry-point.ts
@@ -1,0 +1,30 @@
+import { resolveImport } from 'resolve-import'
+
+export const resolveMockEntryPoint = async (
+  url: URL,
+  module: string,
+  serviceKey: string,
+  key: string,
+  caller: Function | ((...a: any[]) => any)
+): Promise<string> => {
+  let mockedModuleURL: URL
+  if (module.startsWith('./') || module.startsWith('../')) {
+    mockedModuleURL = new URL(module, url)
+  } else {
+    const res = (await resolveImport(module, url)) as URL
+    // caught at the exposed API, defense in depth only
+    // but the experience if it throws here is unhelpful.
+    /* c8 ignore start */
+    if (typeof res === 'string') {
+      const er = new TypeError(
+        'node builtins cannot be mock imported'
+      )
+      Error.captureStackTrace(er, caller)
+      throw er
+    }
+    /* c8 ignore stop */
+    mockedModuleURL = res
+  }
+  mockedModuleURL.searchParams.set('tapmock', `${serviceKey}.${key}`)
+  return String(mockedModuleURL)
+}

--- a/src/mock/test/mock-service.ts
+++ b/src/mock/test/mock-service.ts
@@ -132,7 +132,7 @@ t.test('generate some mock imports', async t => {
   )
   const expect = new URL(mod, import.meta.url)
   expect.searchParams.set('tapmock', `${serviceKey}.${service.key}`)
-  t.equal(service.module, String(expect))
+  t.equal(await service.module, String(expect))
   t.type(service.key, 'string')
   t.match(service, {
     mocks: {
@@ -167,7 +167,7 @@ t.test('generate some mock imports', async t => {
       stack: String,
     },
   })
-  t.strictSame(await import(service.module), {
+  t.strictSame(await import(await service.module), {
     __proto__: null,
     foo: 'bar',
     myFS: 'hello from fs',
@@ -242,39 +242,39 @@ t.test('create with no mocks, nothing to resolve', async t => {
     action: 'resolve',
     id: 'whatever',
     url: './blah.mjs',
-    parentURL: service.module,
+    parentURL: await service.module,
   }), String(expect))
 
   t.equal(await MSCJS.resolve({
     action: 'resolve',
     id: 'whatever',
     url: './blah.mjs',
-    parentURL: service.module,
+    parentURL: await service.module,
   }), String(expect))
 
   t.equal(await service.resolve({
     action: 'resolve',
     id: 'whatever',
     url: './blah.mjs',
-    parentURL: service.module,
+    parentURL: await service.module,
   }), String(expect))
 
   t.equal(await service.resolve({
     action: 'resolve',
     id: 'another one',
     url: './nonexistent.mjs',
-    parentURL: service.module,
+    parentURL: await service.module,
   }), undefined)
   t.equal(await MockService.resolve({
     action: 'resolve',
     id: 'another one',
     url: './nonexistent.mjs',
-    parentURL: service.module,
+    parentURL: await service.module,
   }), undefined)
   t.equal(await MSCJS.resolve({
     action: 'resolve',
     id: 'another one',
     url: './nonexistent.mjs',
-    parentURL: service.module,
+    parentURL: await service.module,
   }), undefined)
 })

--- a/src/mock/test/resolve-mock-entry-point.ts
+++ b/src/mock/test/resolve-mock-entry-point.ts
@@ -1,0 +1,30 @@
+import { resolveImport } from 'resolve-import'
+import t from 'tap'
+
+import { resolveMockEntryPoint } from '../src/resolve-mock-entry-point.js'
+
+t.equal(
+  await resolveMockEntryPoint(
+    new URL(import.meta.url),
+    '../dist/esm/hooks.mjs',
+    'service-key',
+    'mock-key',
+    () => {}
+  ),
+  String(
+    await resolveImport('../dist/esm/hooks.mjs', import.meta.url)
+  ) + '?tapmock=service-key.mock-key'
+)
+
+t.equal(
+  await resolveMockEntryPoint(
+    new URL(import.meta.url),
+    '@tapjs/synonyms',
+    'service-key',
+    'mock-key',
+    () => {}
+  ),
+  String(
+    await resolveImport('@tapjs/synonyms', import.meta.url)
+  ) + '?tapmock=service-key.mock-key'
+)


### PR DESCRIPTION
Fix: https://github.com/tapjs/tapjs/issues/948