### PR TITLE
fix: mock result type

### DIFF
--- a/src/mock/src/index.ts
+++ b/src/mock/src/index.ts
@@ -239,8 +239,11 @@ export class TapMock {
 export type MockedObject<B, O> = O extends Array<any>
   ? O
   : B extends { [k: PropertyKey]: any }
-  ? O extends { [k: string]: any }
-    ? {
+  ? O extends Function 
+  ? O
+  : O extends { [k: string]: any }
+    ?
+      {
         [k in keyof B]: k extends keyof O
           ? MockedObject<B[k], O[k]>
           : B[k]


### PR DESCRIPTION
After mocking object by function produce wrong type
```ts

class MockMeClass {
    fn1() {
        return 'a';
    }
    fn2() {
        return 'b';
    }
}

void t.test('Encoder', (t) => {
    const instance = t.createMock(new MockMeClass(), {
        fn1() {
            return '123457';
        },
    });
})
```

Instance type will:
```ts
 {
    fn1: {};
    fn2: () => string;
}
```
Instead:
```ts
 {
    fn1: () => string;
    fn2: () => string;
}
```