### PR TITLE
tcompare: add valueOf test for  same

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "tap": "^18.0.0-0",
         "trivial-deferred": "^2.0.0",
         "tshy": "^1.2.2",
+        "tsx": "^4.1.2",
         "typedoc": "^0.25.1",
         "typescript": "5.2",
         "walk-up-path": "^3.0.1",
@@ -1533,6 +1534,10 @@
     },
     "node_modules/@tapjs/test": {
       "resolved": "src/test",
+      "link": true
+    },
+    "node_modules/@tapjs/tsx": {
+      "resolved": "src/tsx",
       "link": true
     },
     "node_modules/@tapjs/typescript": {
@@ -3931,9 +3936,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
-      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -24769,6 +24774,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/tsx": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.1.2.tgz",
+      "integrity": "sha512-1spM1bFV6MP2s4tO4tDC7g52fsaFdtEWdO4GfGdqi20qUgPbnAJqixOyIAvCSx1DDj3YIUB4CD06owTWUsOAuQ==",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "get-tsconfig": "^4.7.2",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tuf-js": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.1.0.tgz",
@@ -26066,6 +26090,20 @@
       },
       "bin": {
         "generate-tap-test-class": "scripts/build.mjs"
+      },
+      "engines": {
+        "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
+      },
+      "peerDependencies": {
+        "@tapjs/core": "1.4.5"
+      }
+    },
+    "src/tsx": {
+      "name": "@tapjs/tsx",
+      "version": "1.1.17",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "tsx": "^4.1.2"
       },
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "tap": "^18.0.0-0",
     "trivial-deferred": "^2.0.0",
     "tshy": "^1.2.2",
+    "tsx": "^4.1.2",
     "typedoc": "^0.25.1",
     "typescript": "5.2",
     "walk-up-path": "^3.0.1",

--- a/src/asserts/test/index.ts
+++ b/src/asserts/test/index.ts
@@ -141,6 +141,16 @@ t.test('same, notSame', t => {
   t.ok(a.notSame({ a: 1 }, { a: 1, b: 2 }))
   t.ok(a.notSame({ a: 1 }, { a: 1, b: 2 }))
   t.ok(a.notSame({ a: 1, b: 2 }, { b: 2 }))
+  class Numberish {
+    foo: number
+    valueOf() { return 1 }
+    constructor() {
+      this.foo = Math.random()
+    }
+  }
+  t.ok(a.same(1, new Numberish()))
+  t.ok(a.same(new Numberish(), 1))
+  t.ok(a.same(new Numberish(), new Numberish()))
   t.end()
 })
 

--- a/src/tcompare/src/same.ts
+++ b/src/tcompare/src/same.ts
@@ -105,6 +105,16 @@ export class Same extends Format {
       ? true
       : a === b
       ? true
+      : a instanceof Date && b instanceof Date
+      ? a.getTime() === b.getTime()
+      : typeof a?.valueOf === 'function' &&
+        typeof b?.valueOf === 'function' &&
+        a.valueOf() === b.valueOf()
+      ? true
+      : typeof a?.valueOf === 'function' && a.valueOf() === b
+      ? true
+      : typeof b?.valueOf === 'function' && b.valueOf() === a
+      ? true
       : a === null || b === null
       ? a == b
       : a !== a
@@ -125,8 +135,6 @@ export class Same extends Format {
       ? false
       : Buffer.isBuffer(a) && Buffer.isBuffer(b)
       ? a.equals(b)
-      : a instanceof Date && b instanceof Date
-      ? a.getTime() === b.getTime()
       : a instanceof RegExp && b instanceof RegExp
       ? this.regexpSame(a, b)
       : 'COMPLEX' // might still be a deeper mismatch, of course

--- a/src/tcompare/tap-snapshots/test/same.tsx.test.cjs
+++ b/src/tcompare/tap-snapshots/test/same.tsx.test.cjs
@@ -1236,3 +1236,27 @@ exports[`test/same.tsx > TAP > undefined is the same as itself > must match snap
 exports[`test/same.tsx > TAP > undefined is the same as itself > must match snapshot 3`] = `
 
 `
+
+exports[`test/same.tsx > TAP > valueOf > must match snapshot 1`] = `
+
+`
+
+exports[`test/same.tsx > TAP > valueOf > must match snapshot 2`] = `
+
+`
+
+exports[`test/same.tsx > TAP > valueOf > must match snapshot 3`] = `
+
+`
+
+exports[`test/same.tsx > TAP > valueOf > must match snapshot 4`] = `
+
+`
+
+exports[`test/same.tsx > TAP > valueOf > must match snapshot 5`] = `
+
+`
+
+exports[`test/same.tsx > TAP > valueOf > must match snapshot 6`] = `
+
+`

--- a/src/tcompare/test/same.tsx
+++ b/src/tcompare/test/same.tsx
@@ -794,3 +794,32 @@ t.test('react', t => {
   })
   t.end()
 })
+
+t.test('valueOf', t => {
+  class Numberish {
+    foo: number
+    valueOf() {
+      return 1
+    }
+    constructor() {
+      this.foo = Math.random()
+    }
+  }
+  t.ok(same(t, 1, new Numberish()), 'num to ish')
+  t.ok(same(t, new Numberish(), 1), 'ish to num')
+  t.ok(same(t, new Numberish(), new Numberish()), 'ish to ish')
+  const data = Object.create(null)
+  class DataWrap {
+    foo: number
+    constructor() {
+      this.foo = Math.random()
+    }
+    valueOf() {
+      return data
+    }
+  }
+  t.ok(same(t, data, new DataWrap()), 'data to wrap')
+  t.ok(same(t, new DataWrap(), data), 'wrap to data')
+  t.ok(same(t, new DataWrap(), new DataWrap()), 'wrap to wrap')
+  t.end()
+})

--- a/src/tsx/.tshy/build.json
+++ b/src/tsx/.tshy/build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/src/tsx/.tshy/commonjs.json
+++ b/src/tsx/.tshy/commonjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [
+    ".../src/**/*.mts"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build-tmp/commonjs"
+  }
+}

--- a/src/tsx/.tshy/esm.json
+++ b/src/tsx/.tshy/esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build-tmp/esm"
+  }
+}

--- a/src/tsx/LICENSE.md
+++ b/src/tsx/LICENSE.md
@@ -1,0 +1,55 @@
+# Blue Oak Model License
+
+Version 1.0.0
+
+## Purpose
+
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules. The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+<https://blueoakcouncil.org/license/1.0.0>.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with [Notices](#notices), you can keep your
+license by taking all practical steps to comply within 30
+days after the notice. If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+**_As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim._**

--- a/src/tsx/README.md
+++ b/src/tsx/README.md
@@ -1,0 +1,5 @@
+# `@tapjs/tsx`
+
+An alternative plugin to `@tapjs/typescript`. Load typescript
+tests using [`tsx`](https://github.com/privatenumber/tsx) instead
+of [`ts-node`](https://github.com/TypeStrong/ts-node).

--- a/src/tsx/loader.mjs
+++ b/src/tsx/loader.mjs
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'url'
+
+// check if we need a globalPreload, because node 20 runs
+// loaders in separate isolated loaders thread.
+
+const v = process.version
+  .replace(/[^0-9]/g, ' ')
+  .trim()
+  .split(' ')
+  .map(s => parseInt(s, 10))
+const separateLoadersThread = v[0] >= 20
+
+const base = fileURLToPath(import.meta.url)
+export const globalPreload = () =>
+  !separateLoadersThread
+    ? ''
+    : `
+const { createRequire } = getBuiltin('module')
+const require = createRequire(${JSON.stringify(base)})
+require('@esbuild-kit/cjs')
+`
+
+// otherwise, do it here
+if (!separateLoadersThread) {
+  await import('@esbuild-kit/cjs-loader')
+}
+
+export * from '@esbuild-kit/esm-loader'

--- a/src/tsx/package.json
+++ b/src/tsx/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@tapjs/tsx",
+  "version": "1.1.17",
+  "description": "Alternative to @tapjs/typescript. Load typescript using tsx instead of ts-node.",
+  "tshy": {
+    "main": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts",
+      "./loader": "./src/loader.mts",
+      "./import": "./src/import.mts"
+    }
+  },
+  "type": "module",
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./loader": {
+      "import": {
+        "types": "./dist/esm/loader.d.mts",
+        "default": "./dist/esm/loader.mjs"
+      }
+    },
+    "./import": {
+      "import": {
+        "types": "./dist/esm/import.d.mts",
+        "default": "./dist/esm/import.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepare": "tshy",
+    "pretest": "npm run prepare",
+    "presnap": "npm run prepare",
+    "test": "tap",
+    "snap": "tap",
+    "format": "prettier --write . --loglevel warn --ignore-path ../../.prettierignore --cache",
+    "typedoc": "typedoc --tsconfig tsconfig/esm.json ./src/*.ts"
+  },
+  "license": "BlueOak-1.0.0",
+  "dependencies": {
+    "tsx": "^4.1.2"
+  },
+  "peerDependencies": {
+    "@tapjs/core": "1.4.5"
+  },
+  "tap": {
+    "typecheck": false
+  },
+  "keywords": [
+    "tapjs plugin"
+  ],
+  "engines": {
+    "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
+  }
+}

--- a/src/tsx/src/import.mts
+++ b/src/tsx/src/import.mts
@@ -1,0 +1,2 @@
+//@ts-ignore
+export * from 'tsx'

--- a/src/tsx/src/index.ts
+++ b/src/tsx/src/index.ts
@@ -1,0 +1,75 @@
+// Exports a loader, which does all the work.
+// import('tsx')
+// import('@tapjs/core')
+export const loader = '@tapjs/tsx/loader'
+export const importLoader = '@tapjs/tsx/import'
+export const preload = true
+import type { TapPlugin } from '@tapjs/core'
+
+// the plugin just sets the configs for tsx, doesn't
+// add any functionality to the Test class.
+const env = (...keys: string[]) => {
+  for (const key of keys) {
+    if (process.env[`TAP_${key}`]) {
+      process.env[key] = process.env[`TAP_${key}`]
+    }
+  }
+}
+let didWarning = false
+let didEnv = false
+
+/**
+ * File types that this plugin adds support for
+ */
+export const testFileExtensions = ['ts', 'cts', 'mts', 'tsx', 'jsx']
+
+/**
+ * Plugin function enabling tsx for running typescript tests
+ *
+ * The plugin function sets the tsx environment variables based on the tap
+ * configs, and prints a warning when used along with the `@tapjs/typescript`
+ * plugin, as this can cause strange conflicts, or at the very least,
+ * unnecessarily slow down tests by compiling the typescript twice.
+ */
+export const plugin: TapPlugin<{}> = () => {
+  if (!didEnv) {
+    env('TSX_TSCONFIG_PATH', 'TSX_DISABLE_CACHE')
+  }
+  const tp = process.env.TAP_PLUGIN || ''
+  if (!/^!@tapjs\/typescript$/m.test(tp) && !didWarning) {
+    didWarning = true
+    console.error(`
+@tapjs/tsx may behave strangely when used along with
+the @tapjs/typescript default plugin.
+
+Please run: tap plugin rm @tapjs/typescript
+`)
+  }
+  return {}
+}
+
+/**
+ * Configuration fields added by this plugin.
+ *
+ * @group Configuration
+ */
+export const config = {
+  /**
+   * String option. Tell `tsx` where to find your tsconfig.json file.
+   *
+   * @group Configuration
+   */
+  'tsx-tsconfig-path': {
+    type: 'string',
+    description: `Tell tsx where to find your tsconfig.json file.`,
+  },
+  /**
+   * Flag. Tell `tsx` not to use a cache
+   *
+   * @group Configuration
+   */
+  'tsx-disable-cache': {
+    type: 'boolean',
+    description: `Tell tsx not to use a cache`,
+  },
+}

--- a/src/tsx/src/loader.mts
+++ b/src/tsx/src/loader.mts
@@ -1,0 +1,4 @@
+//@ts-ignore
+export * from 'tsx/esm'
+//@ts-ignore
+import 'tsx/cjs'

--- a/src/tsx/tap-snapshots/test/index.js.test.cjs
+++ b/src/tsx/tap-snapshots/test/index.js.test.cjs
@@ -1,0 +1,22 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/index.js > TAP > config 1`] = `
+Object {
+  "esbk-disable-cache": Object {
+    "description": "Tell @esbuild-kit not to use a cache",
+    "type": "boolean",
+  },
+  "esbk-tsconfig-path": Object {
+    "description": String(
+      Tell @esbuild-kit where to find your
+                        tsconfig.json file.
+    ),
+    "type": "string",
+  },
+}
+`

--- a/src/tsx/tap-snapshots/test/index.ts.test.cjs
+++ b/src/tsx/tap-snapshots/test/index.ts.test.cjs
@@ -1,0 +1,19 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/index.ts > TAP > config 1`] = `
+Object {
+  "tsx-disable-cache": Object {
+    "description": "Tell tsx not to use a cache",
+    "type": "boolean",
+  },
+  "tsx-tsconfig-path": Object {
+    "description": "Tell tsx where to find your tsconfig.json file.",
+    "type": "string",
+  },
+}
+`

--- a/src/tsx/test/import-deps.ts
+++ b/src/tsx/test/import-deps.ts
@@ -1,0 +1,85 @@
+import { readFile } from 'fs/promises'
+import { glob } from 'glob'
+import { isBuiltin } from 'module'
+import { resolve } from 'path'
+import t from 'tap'
+import { fileURLToPath } from 'url'
+
+const src = fileURLToPath(new URL('../src', import.meta.url))
+const files = await glob('**/*.@(ts|tsx|mts|cts)', {
+  cwd: src,
+  posix: true,
+})
+
+const {
+  name: pkgName,
+  dependencies,
+  peerDependencies,
+} = JSON.parse(
+  await readFile(resolve(src, '../package.json'), 'utf8')
+) as {
+  name: string
+  dependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+const deps = { ...dependencies, ...peerDependencies }
+
+const importRe =
+  /(?:\n|^)(?:im|ex)port (?!type [\s\S\n]+?from)(?:[\s\S\n]*?from )?'(@[^\/]+\/[^'\/]+|[^\.][^'\/]+)(\/[^']+)?'/g
+const asyncImportRe =
+  /import\('(@[^\/]+\/[^'\/]+|[^\.][^'\/]+)(\/[^']+)?'\)/g
+const foundIn = new Map<string, string[]>()
+for (const file of files) {
+  const content = await readFile(resolve(src, file), 'utf8')
+  let m: null | (RegExpExecArray & [string, string])
+  const deps = new Set<string>()
+  while (
+    null !==
+    (m = importRe.exec(content) as
+      | null
+      | (RegExpExecArray & [string, string]))
+  ) {
+    if (isBuiltin(m[1]) || m[1] === pkgName) continue
+    t.comment(file, m.index, [...m])
+    deps.add(m[1])
+  }
+  while (
+    null !==
+    (m = asyncImportRe.exec(content) as
+      | null
+      | (RegExpExecArray & [string, string]))
+  ) {
+    if (isBuiltin(m[1]) || m[1] === pkgName) continue
+    deps.add(m[1])
+  }
+  for (const dep of deps) {
+    const f = foundIn.get(dep) || []
+    f.push(file)
+    foundIn.set(dep, f)
+  }
+}
+
+if (
+  !foundIn.size &&
+  (pkgName === '@tapjs/test' || !Object.keys(deps).length)
+) {
+  t.pass('no deps to check')
+} else {
+  if (pkgName !== '@tapjs/test') {
+    for (const dep of Object.keys(deps)) {
+      t.ok(foundIn.get(dep), 'declared, should be used: ' + dep, {
+        [dep]: deps[dep],
+      })
+      foundIn.delete(dep)
+    }
+  }
+  for (const [dep, f] of foundIn.entries()) {
+    t.match(
+      deps,
+      { [dep]: String },
+      'loaded, should be declared: ' + dep,
+      { paths: f }
+    )
+  }
+}

--- a/src/tsx/test/index.ts
+++ b/src/tsx/test/index.ts
@@ -1,0 +1,55 @@
+import { TestBase } from '@tapjs/core'
+import t from 'tap'
+import { config, plugin } from '../dist/esm/index.js'
+
+t.matchSnapshot(config, 'config')
+
+t.equal(t.pluginLoaded(plugin), false, 'plugin not loaded by default')
+
+const originalEnv = { ...process.env }
+t.beforeEach(t =>
+  t.intercept(process, 'env', { value: { ...originalEnv } })
+)
+
+t.test('apply plugin to a test object', t => {
+  const errs = t.capture(console, 'error')
+  const tb = new TestBase({ name: 'tsx test' })
+  const res = plugin(tb)
+  t.strictSame(res, {}, 'just an empty object')
+  t.strictSame(errs.args(), [
+    [
+      '\n' +
+        '@tapjs/tsx may behave strangely when used along with\n' +
+        'the @tapjs/typescript default plugin.\n' +
+        '\n' +
+        'Please run: tap plugin rm @tapjs/typescript\n',
+    ],
+  ])
+  t.end()
+})
+
+t.test('only warn one time', t => {
+  const errs = t.capture(console, 'error')
+  const tb = new TestBase({ name: 'tsx test' })
+  const res = plugin(tb)
+  t.strictSame(res, {}, 'just an empty object')
+  t.strictSame(errs.args(), [])
+  t.end()
+})
+
+t.test('set the configs from tap configs', async t => {
+  t.capture(console, 'error')
+  delete process.env.TSX_TSCONFIG_PATH
+  delete process.env.TSX_DISABLE_CACHE
+  process.env.TAP_TSX_TSCONFIG_PATH = 'some-path'
+  process.env.TAP_TSX_DISABLE_CACHE = '1'
+  const { plugin } = (await t.mockImport(
+    '../dist/esm/index.js'
+  )) as typeof import('../dist/esm/index.js')
+  const tb = new TestBase({ name: 'tsx env test' })
+  plugin(tb)
+  t.match(process.env, {
+    TSX_TSCONFIG_PATH: 'some-path',
+    TSX_DISABLE_CACHE: '1',
+  })
+})

--- a/src/tsx/tsconfig.json
+++ b/src/tsx/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
+  }
+}

--- a/src/tsx/typedoc.json
+++ b/src/tsx/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "tsconfig": "./.tshy/esm.json",
+  "entryPoints": ["./src/**/*.+(ts|tsx|mts)"]
+}


### PR DESCRIPTION
Issue: #971 

Object instances that overwrite `.valueOf` to a primitive value are not loosely compared. Native object wrappers for primitives work fine, but custom objects do not.

## For example

### Passes
```javascript
test.same(1, new Number(1)) 
```
### Fails
```javascript
class Numberish { typeOf() { return 1 } }
test.same(1, new Numberish()) 
```