### PR TITLE
fix(test): use cross-spawn to make npm on windows work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,6 +1596,14 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/diff": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.5.tgz",
@@ -26078,6 +26086,8 @@
         "@tapjs/stdin": "1.1.17",
         "@tapjs/typescript": "1.3.6",
         "@tapjs/worker": "1.1.17",
+        "@types/cross-spawn": "^6.0.6",
+        "cross-spawn": "^7.0.3",
         "glob": "^10.3.10",
         "jackspeak": "^2.3.6",
         "mkdirp": "^3.0.0",

--- a/src/test/package.json
+++ b/src/test/package.json
@@ -103,6 +103,8 @@
     "@tapjs/stdin": "1.1.17",
     "@tapjs/typescript": "1.3.6",
     "@tapjs/worker": "1.1.17",
+    "@types/cross-spawn": "^6.0.6",
+    "cross-spawn": "^7.0.3",
     "glob": "^10.3.10",
     "jackspeak": "^2.3.6",
     "mkdirp": "^3.0.0",

--- a/src/test/scripts/build.mts
+++ b/src/test/scripts/build.mts
@@ -1,7 +1,7 @@
 import { globSync } from 'glob'
 import { ConfigOptionBase, isConfigOption } from 'jackspeak'
 import { mkdirp, mkdirpSync } from 'mkdirp'
-import { spawnSync } from 'node:child_process'
+import spawn from 'cross-spawn'
 import { readFileSync, symlinkSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { basename, resolve } from 'node:path'
@@ -429,7 +429,11 @@ writeFileSync(
 const nm = resolve(dir, 'node_modules')
 mkdirpSync(resolve(nm, '@tapjs'))
 symlinkSync('../..', resolve(nm, '@tapjs/test-built'))
-spawnSync('npm', ['run', 'prepare'], { cwd: dir, stdio: 'inherit' })
+const res = spawn.sync('npm', ['run', 'prepare'], { cwd: dir, stdio: 'inherit' })
+if (res.status != 0) {
+  console.error(`'npm run prepare' failed with status code ${res.status}. Error: `, res.error)
+  process.exit(1)
+}
 rimrafSync(nm)
 
 export {}


### PR DESCRIPTION
Fixes #988 

Use cross-spawn instead of the regular Node spawn. No tests added because the tests were already failing on Windows.