### PR TITLE
fix: loaders 20.5

### DIFF
--- a/src/mock/src/hooks.mts
+++ b/src/mock/src/hooks.mts
@@ -7,6 +7,9 @@ import { MockServiceClient } from './mock-service-client.js'
 
 let client: MockServiceClient
 
+let loadWorks = false
+let resolveWorks = false
+
 export const globalPreload: GlobalPreloadHook = ({ port }) => {
   // loader thread. connect client
   client = new MockServiceClient(port)
@@ -32,6 +35,10 @@ export const initialize = ({ port }: { port: MessagePort }): void => {
 }
 
 export const load: LoadHook = async (url, context, nextLoad) => {
+  if (!client && !loadWorks) {
+    return nextLoad(url, context)
+  }
+  loadWorks = true
   if (!client) {
     throw new Error(
       'initialize() or globalPreload() must be run prior to ' +
@@ -54,6 +61,10 @@ export const resolve: ResolveHook = async (
   context,
   nextResolve,
 ) => {
+  if (!client && !resolveWorks) {
+    return nextResolve(url, context)
+  }
+  resolveWorks = true
   if (!client) {
     throw new Error(
       'initialize() or globalPreload() must be run prior to ' +


### PR DESCRIPTION
related: https://github.com/tapjs/tapjs/issues/950

so some versions of node (19 - 20 ) in the transition from `--loaders` to `--imports` broke the execution order of loaders, in a way the spec around loaders using other loaders was kinda janky.


looking at https://github.com/tapjs/tapjs/blob/main/src/run/src/test-argv.ts#L44-L51 and pulling out combinations of what's generated for 20.5 we see 

```
node \
--loader=./node_modules/@isaacs/ts-node-temp-fork-for-pr-2009/esm.mjs \
--loader=./node_modules/@tapjs/mock/dist/esm/legacy-loader.mjs \
--enable-source-maps \
--loader=./node_modules/@tapjs/processinfo/dist/esm/loader-legacy.mjs \
./test/main.js
```

this fails, however when you remove the `processinfo` loader it passes, or when you remove the `mock` it works, which led me to think this was an error with chaining the two.

the issue lies in the mock loader reading in the processinfo imports before the mock has be initialized this can be fixed in three ways.

1) just don't throw for the mock loader, the initial calls are all from processinfo then the mock loader initializes and it works again
1) as in this pr, don't throw after the mock loader has initialized the client
2) some kind of janky ban list of modules that processinfo uses like which works but it's really manual

```js
const invalid = (url) => {
    if (!url) return false
    return (
        url.includes('/node_modules/@tapjs/processinfo') ||
        url.includes('/node_modules/uuid/') ||
        url.includes('/node_modules/process-on-spawn/') ||
        url.includes('/node_modules/signal-exit/') ||
        url.includes('/node_modules/pirates/') ||
        url.includes('/node_modules/signal-exit/') ||
        url === 'node:inspector'
    )
}
```

