### PR TITLE
fix: escape executable file path for shell

### DIFF
--- a/src/test/src/build.mts
+++ b/src/test/src/build.mts
@@ -456,6 +456,9 @@ writeFileSync(
 )
 
 const escapeSpacesInFilePath = (filePath: string): string => {
+  if (process.platform === 'win32') {
+    return `"${filePath}"`;
+  }
   return filePath.replace(/(\s+)/g, '\\$1')
 }
 

--- a/src/test/src/build.mts
+++ b/src/test/src/build.mts
@@ -455,11 +455,15 @@ writeFileSync(
   }),
 )
 
+const escapeSpacesInFilePath = (filePath: string): string => {
+  return filePath.replace(/(\s+)/g, '\\$1')
+}
+
 const tshy = fileURLToPath(
   await resolveImport('tshy', import.meta.url),
 )
 
-const res = spawnSync(process.execPath, [tshy], {
+const res = spawnSync(escapeSpacesInFilePath(process.execPath), [tshy], {
   shell: true,
   cwd: dir,
   stdio: 'inherit',


### PR DESCRIPTION
Fixes https://github.com/tapjs/tapjs/issues/1030

This PR introduces a change to how the executable path for `node` is passed on to the shell. In certain scenarios, `node` can be installed in a path that includes spaces; in this case, the `/bin/sh` shell cannot correctly interpret spaces, and so the tap build process fails.

**Things this PR is missing**

1. Tests (@isaacs if you can please show me how this is being tested today, I'd be happy to add tests).
2. Clarity on how to handle this on Windows. I notice that there's a whole package dedicated to this – https://github.com/jy95/escape-path-with-spaces?tab=readme-ov-file#escape-path-with-spaces – but once again, need guidance from @isaacs to know if I should use this. EDIT: For now, I've simply followed the official advice on https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows

**How this was tested**

1. Checkout branch from https://github.com/paambaati/codeclimate-action/pull/753
2. Make the change locally to the `build.mjs` file locally in `node_modules`
3. Run `pnpm run test`
4. Watch tests succeed!

    <img width="998" alt="Screenshot 2024-06-11 at 2 52 04 PM" src="https://github.com/tapjs/tapjs/assets/5381764/9e4e82b2-5402-4847-bb10-029447f28150">
