### PR TITLE
Fix broken "skipping-everything" link in tap-parser

### DIFF
--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -206,7 +206,7 @@ Every `/^\d+\.\.\d+/` line emits a `'plan'` event for the test numbers
 `plan.start` through `plan.end`, inclusive.
 
 If the test is [completely
-skipped](http://podwiki.hexten.net/TAP/TAP.html?page=TAP#Skippingeverything)
+skipped](https://testanything.org/tap-version-14-specification.html#skipping-everything)
 the result will look like
 
 ```


### PR DESCRIPTION
Ref https://testanything.org/tap-version-14-specification.html#skipping-everything.