### PR TITLE
Fix for Issue 1044 🐞 Unable to run tap build or install plugins when using a private registry with authentication

### DIFF
--- a/src/run/src/plugin.ts
+++ b/src/run/src/plugin.ts
@@ -86,7 +86,11 @@ export const plugin = async (
   }
 }
 
-const add = async (args: string[], config: LoadedConfig, quiet = false) => {
+const add = async (
+  args: string[],
+  config: LoadedConfig,
+  quiet = false,
+) => {
   const error = quiet ? () => {} : console.error
   const log = quiet ? () => {} : console.log
   if (!args.length) throw new Error('no plugin name provided')

--- a/src/run/test/select-version.ts
+++ b/src/run/test/select-version.ts
@@ -36,37 +36,6 @@ const abbrevPacku: Packument = {
   ),
 }
 
-t.test('registry lookup returns error', async t => {
-  const { selectVersion } = await t.mockImport<
-    typeof import('../dist/esm/select-version.js')
-  >('../dist/esm/select-version.js', {
-    '../dist/esm/npm.js': {
-      npmBg: () => ({
-        error: new Error('nope'),
-      }),
-    },
-  })
-  t.rejects(selectVersion('x', '*', config), {
-    message: 'nope',
-  })
-})
-
-t.test('registry lookup fails', async t => {
-  const { selectVersion } = await t.mockImport<
-    typeof import('../dist/esm/select-version.js')
-  >('../dist/esm/select-version.js', {
-    '../dist/esm/npm.js': {
-      npmBg: () => ({
-        status: 1,
-        stderr: 'some error messages',
-      }),
-    },
-  })
-  t.rejects(selectVersion('x', '*', config), {
-    message: 'failed to look up npm registry: some error messages',
-  })
-})
-
 t.test('look up a version that has a peer dep', async t => {
   const { selectVersion } = await t.mockImport<
     typeof import('../dist/esm/select-version.js')


### PR DESCRIPTION
Removed lookup of registry as `pacote` already handles getting the npm registry better (it includes authentication). Removing the specific registry config passed to pacote allows it to correctly handle private repositories. I have also removed the tests associated with this lookup.

Fix for: https://github.com/tapjs/tapjs/issues/1044