### PR TITLE
Update repository URL for tap-yaml

### DIFF
--- a/src/yaml/package.json
+++ b/src/yaml/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tapjs/tap-yaml.git"
+    "url": "git+https://github.com/tapjs/tapjs.git"
   },
   "keywords": [
     "tap",


### PR DESCRIPTION
Simply change the repository URL in the metadata for [tap-yaml](https://www.npmjs.com/package/tap-yaml) to point to this repository.

This helps increase transparency, especially for automated tools for whom it's not obvious that you should follow the ["moved to xyz" link](https://github.com/tapjs/tap-yaml/blob/7fa72c6bc8707830ffb08a5b53635a04ce64f803/README.md?plain=1#L1).