### PR TITLE
feature(coverage): support minimum coverage thresholds

### DIFF
--- a/src/config/src/jack.ts
+++ b/src/config/src/jack.ts
@@ -484,6 +484,53 @@ export default jack({
     },
   })
 
+  .num({
+    statements: {
+      description: `what % of statements must be covered?`,
+      hint: 'n',
+      validate: (n: unknown) => { 
+        if (typeof n !== 'number' || n < 0 || n > 100) {
+          throw new Error('Coverage percentage must be between 0 and 100')
+        }
+        return true
+      },
+      default: 100
+    },
+    branches: {
+      description: `what % of branches must be covered?`,
+      hint: 'n',
+      validate: (n: unknown) => { 
+        if (typeof n !== 'number' || n < 0 || n > 100) {
+          throw new Error('Coverage percentage must be between 0 and 100')
+        }
+        return true
+      },
+      default: 100
+    },
+    lines: {
+      description: `what % of lines must be covered?`,
+      hint: 'n',
+      validate: (n: unknown) => { 
+        if (typeof n !== 'number' || n < 0 || n > 100) {
+          throw new Error('Coverage percentage must be between 0 and 100')
+        }
+        return true
+      },
+      default: 100
+    },
+    functions: {
+      description: `what % of functions must be covered?`,
+      hint: 'n',
+      validate: (n: unknown) => { 
+        if (typeof n !== 'number' || n < 0 || n > 100) {
+          throw new Error('Coverage percentage must be between 0 and 100')
+        }
+        return true
+      },
+      default: 100
+    }
+  })
+
   .flag({
     bail: {
       short: 'b',

--- a/src/config/tap-snapshots/test/jack.ts.test.cjs
+++ b/src/config/tap-snapshots/test/jack.ts.test.cjs
@@ -60,6 +60,13 @@ Object {
     "hint": "module",
     "type": "string",
   },
+  "branches": Object {
+    "default": 100,
+    "description": "what % of branches must be covered?",
+    "hint": "n",
+    "type": "number",
+    "validate": Function validate(n),
+  },
   "browser": Object {
     "default": true,
     "description": String(
@@ -187,6 +194,13 @@ Object {
     "multiple": true,
     "type": "string",
   },
+  "functions": Object {
+    "default": 100,
+    "description": "what % of functions must be covered?",
+    "hint": "n",
+    "type": "number",
+    "validate": Function validate(n),
+  },
   "help": Object {
     "description": "show this help banner",
     "short": "h",
@@ -244,6 +258,13 @@ Object {
     "hint": "n",
     "short": "j",
     "type": "number",
+  },
+  "lines": Object {
+    "default": 100,
+    "description": "what % of lines must be covered?",
+    "hint": "n",
+    "type": "number",
+    "validate": Function validate(n),
   },
   "no-bail": Object {
     "description": "Do not bail out on first failure (default)",
@@ -427,6 +448,13 @@ Object {
       When running \`tap report text --no-show-full-coverage\`, explicitly requesting a text report and also explicitly requesting that full coverage text report *not* be shown, then a summary report will be printed instead of the full text report.
     ),
     "type": "boolean",
+  },
+  "statements": Object {
+    "default": 100,
+    "description": "what % of statements must be covered?",
+    "hint": "n",
+    "type": "number",
+    "validate": Function validate(n),
   },
   "test-arg": Object {
     "default": Array [],

--- a/src/config/test/jack.ts
+++ b/src/config/test/jack.ts
@@ -9,3 +9,58 @@ t.throws(() =>
   //@ts-expect-error
   jack.setConfigValues({ 'unknown key': ['invalid'] }),
 )
+
+t.test('coverage threshold validation', async t => {
+  const coverageSettings = [
+    'statements',
+    'branches',
+    'functions',
+    'lines'
+  ]
+  for (const setting of coverageSettings) {
+    t.throws(() => {
+      const conf = jack.parse([`--${setting}=invalid`])
+      const data: Record<string, any> = Object.fromEntries(
+        Object.entries(conf.values).map(([k, v]) => [
+          k,
+          Array.isArray(v) ? [...v] : v,
+        ]),
+      )
+      //@ts-expect-error
+      jack.validate(data)
+    })
+    t.throws(() => {
+      const conf = jack.parse([`--${setting}=-1`])
+      const data: Record<string, any> = Object.fromEntries(
+        Object.entries(conf.values).map(([k, v]) => [
+          k,
+          Array.isArray(v) ? [...v] : v,
+        ]),
+      )
+      //@ts-expect-error
+      jack.validate(data)
+    })
+    t.throws(() => {
+      const conf = jack.parse([`--${setting}=101`])
+      const data: Record<string, any> = Object.fromEntries(
+        Object.entries(conf.values).map(([k, v]) => [
+          k,
+          Array.isArray(v) ? [...v] : v,
+        ]),
+      )
+      //@ts-expect-error
+      jack.validate(data)
+    })
+    t.doesNotThrow(() => {
+      const conf = jack.parse([`--${setting}=0`])
+      const data: Record<string, any> = Object.fromEntries(
+        Object.entries(conf.values).map(([k, v]) => [
+          k,
+          Array.isArray(v) ? [...v] : v,
+        ]),
+      )
+      //@ts-expect-error
+      jack.validate(data)
+    })
+  }
+})

--- a/src/docs/content/coverage.md
+++ b/src/docs/content/coverage.md
@@ -16,7 +16,7 @@ judge of test completeness. Code coverage is thus the "test for
 the tests", verifying that the tests are in fact testing the
 code. Nothing is perfect, and it is of course possible to write
 bad tests with full code coverage, but _lacking_ test coverage
-virtually gaurantees that tests are inadequate.
+virtually guarantees that tests are inadequate.
 
 As the saying goes, seatbelts don't make you immortal, but
 they're still a good idea.
@@ -32,14 +32,41 @@ generated. If it is incomplete, or if no coverage is generated at
 all, then a report is printed and the process exits with an error
 status code.
 
+If 100% coverage is not possible, you can set minimum code
+coverage thresholds for statements, branches, functions, and
+lines. The default will be 100 for any coverage threshold that is
+not set explicitly.
+
+Minimum coverage can be set via configuration files:
+
+```yaml
+statements: 90
+branches: 90
+functions: 90
+lines: 90
+```
+
+Minimum coverage can be set via command line switches:
+
+```bash
+tap --statements=90 --branches=90 --functions=90 --lines=90
+```
+
+In the following example, functions and lines will have the
+default of 100 because they are not explicitly set.
+
+```bash
+tap --statements=90 --branches=90
+```
+
 ## Reporting Coverage
 
 Tap uses essentially the same strategy as
-[C8](https://www.npmjs.com/package/c8), but instead of
-generating coverage information for _all_ JavaScript that passes
-through the interpreter, it only saves coverage for the files
-that are part of your program. This saves a considerable amount
-of disk space and, more importantly, processing time.
+[C8](https://www.npmjs.com/package/c8), but instead of generating
+coverage information for _all_ JavaScript that passes through the
+interpreter, it only saves coverage for the files that are part
+of your program. This saves a considerable amount of disk space
+and, more importantly, processing time.
 
 To generate coverage reports, tap uses the C8 `Reporter` class.
 Thus, any [istanbul

--- a/src/docs/content/upgrading-from-16.md
+++ b/src/docs/content/upgrading-from-16.md
@@ -1,12 +1,12 @@
 ---
-title: Upgrading to tap 18 from tap v16 and before
+title: Upgrading from tap v16 and before
 eleventyNavigation:
   order: 495
   key: Upgrading
 ---
 
-Tap version 18 is a major overhaul, and some configuration needs to be
-updated when upgrading from versions 16 and before.
+Tap version 18 was a major overhaul, and some configuration needs
+to be updated when upgrading from versions 16 and before.
 
 The [changelog](./changelog.md) covers much of the details, but
 this is intended to be a more deliberate guide for users
@@ -24,8 +24,8 @@ replace that with just `/.tap`.
 In tap 16, a top-level function `tap.mochaGlobals()` would dump
 the various mocha-like interfaces onto the global object.
 
-In tap 18, these are provided by the optional [`@tapjs/mocha-globals`
-plugin](./plugins/mocha-globals.md).
+In tap 18, these are provided by the optional
+[`@tapjs/mocha-globals` plugin](./plugins/mocha-globals.md).
 
 To use it, add the plugin:
 
@@ -63,6 +63,9 @@ In tap v18, this interface has changed:
 
 - Coverage is enabled by default, and checked
 - Missing or incomplete coverage is treated as an error
+- Coverage is considered incomplete when it does not meet minimum
+  coverage thresholds
+  - The default minimum coverage threshold is 100%
 
 You can get the v16 style `--no-cov` behavior by doing:
 
@@ -89,7 +92,8 @@ To generate a coverage report after the fact, you can run `tap
 report [type]`.
 
 To replay the entire previous test run without actually running
-tests (ie, just report the results again), you can run `tap replay`.
+tests (ie, just report the results again), you can run `tap
+replay`.
 
 ## `test-regexp`, `test-ignore` RegExp -> `include`, `exclude` globs
 

--- a/src/run/src/report.ts
+++ b/src/run/src/report.ts
@@ -187,12 +187,12 @@ const checkCoverage = async (report: Report, config: LoadedConfig) => {
     return
   }
 
-  // TODO: make levels configurable, just *default* to 100
-  // only comment it if not using the text reporter, because that makes
-  // it pretty obvious where the shortcomings are already.
+  // TODO: Only comment lack of coverage if not using the text reporter, 
+  // because that makes it pretty obvious where the shortcomings are already.
   for (const th of thresholds) {
     const coverage = Number(summary[th].pct) || 0
-    if (coverage < 100) {
+    const minCoverage = Number(config.get(th))
+    if (coverage < minCoverage) {
       if (comment) {
         t.comment(`ERROR: incomplete ${th} coverage (${coverage}%)`)
       }
@@ -200,7 +200,7 @@ const checkCoverage = async (report: Report, config: LoadedConfig) => {
     }
   }
   if (success === false) {
-    t.debug('run/report exit=1 coverage not 100', summary)
+    t.debug(`run/report exit=1 coverage is incomplete`, summary)
     if (!config.get('allow-incomplete-coverage')) {
       process.exitCode = 1
     }


### PR DESCRIPTION
There are many, I assume, that would like to continue using node-tap, and keep their dependencies updated, but either aren't ready for, or don't wish to subscribe to, 100% code coverage philosophy/ideology. This PR addresses this by "bringing back" minimum code coverage thresholds.

Please let me know if there is any additional work, or changes, and I'll address the feedback promptly.

Related issues:
- https://github.com/tapjs/tapjs/issues/979
- https://github.com/tapjs/tapjs/issues/877
  - Not directly related to the issue but related to comments on the issue regarding thresholds