### PR TITLE
parser: handle empty yaml

### DIFF
--- a/src/parser/src/index.ts
+++ b/src/parser/src/index.ts
@@ -358,6 +358,7 @@ export class Parser extends EventEmitter implements NodeJS.WritableStream {
     }
 
     if (
+      diags &&
       typeof diags.duration_ms === 'number' &&
       this.#current.time === null
     ) {

--- a/src/parser/test/empty-yaml.ts
+++ b/src/parser/test/empty-yaml.ts
@@ -1,0 +1,26 @@
+import { Readable } from 'stream'
+import { Parser } from '../dist/esm/index.js'
+import t from 'tap'
+
+const data = [
+  'TAP version 13',
+  '1..2',
+  'ok 1 - test passes',
+  '  ---',
+  '  ...',
+  'ok 2 - another test',
+]
+
+t.test('empty yaml blocks', function (t) {
+  const r = new Readable()
+  r.push(data.join('\n'))
+  r.push(null)
+
+  const p = new Parser()
+  r.pipe(p)
+  p.on('complete', r => {
+    t.equal(r.ok, true)
+    t.equal(r.count, 2)
+    t.end()
+  })
+})


### PR DESCRIPTION
Do not throw an error on empty yaml.

fix: https://github.com/tapjs/tapjs/issues/1056