### PR TITLE
Avoid shell execution for child processes in npm and reporter logic

### DIFF
--- a/src/run/src/handle-reporter.ts
+++ b/src/run/src/handle-reporter.ts
@@ -73,7 +73,7 @@ export const handleReporter = async (t: TAP, config: LoadedConfig) => {
     const exe = await which(reporter)
     const rargs = config.get('reporter-arg') || []
     const proc = spawn(exe, rargs, {
-      shell: true,
+      shell: false,
       stdio,
     })
     if (proc.stdout) proc.stdout.pipe(out)

--- a/src/run/src/npm.ts
+++ b/src/run/src/npm.ts
@@ -21,18 +21,21 @@ export const npmFindCwd = async (projectRoot: string): Promise<string> => {
   return npmCwd
 }
 
+// exported for testing
+export const npmExe = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
 /**
  * Run an npm command in the background, returning the result
  */
 export const npmBg = (args: string[], npmCwd: string) => {
-  return spawnSync('npm', args, {
+  return spawnSync(npmExe, args, {
     env: {
       ...npmFreeEnv,
       npm_config_prefix: npmCwd,
     },
     encoding: 'utf8',
     cwd: npmCwd,
-    shell: true,
+    shell: false,
   })
 }
 
@@ -54,7 +57,7 @@ const npmFg = (
     | undefined,
 ) => {
   return foregroundChild(
-    'npm',
+    npmExe,
     args,
     {
       env: {
@@ -62,7 +65,7 @@ const npmFg = (
         npm_config_prefix: npmCwd,
       },
       cwd: npmCwd,
-      shell: true,
+      shell: false,
     },
     cb,
   )

--- a/src/run/tap-snapshots/test/npm.ts.test.cjs
+++ b/src/run/tap-snapshots/test/npm.ts.test.cjs
@@ -26,7 +26,7 @@ Array [
       "env": Object {
         "ok": true,
       },
-      "shell": true,
+      "shell": false,
     },
     Function (code, signal),
   ],
@@ -48,7 +48,7 @@ Array [
       "env": Object {
         "ok": true,
       },
-      "shell": true,
+      "shell": false,
     },
   ],
 ]
@@ -74,7 +74,7 @@ Array [
       "env": Object {
         "ok": true,
       },
-      "shell": true,
+      "shell": false,
     },
     Function (code, signal),
   ],
@@ -102,7 +102,7 @@ Array [
       "env": Object {
         "ok": true,
       },
-      "shell": true,
+      "shell": false,
     },
     Function (code, signal),
   ],
@@ -124,7 +124,7 @@ Array [
       "env": Object {
         "ok": true,
       },
-      "shell": true,
+      "shell": false,
     },
   ],
 ]
@@ -150,7 +150,7 @@ Array [
       "env": Object {
         "ok": true,
       },
-      "shell": true,
+      "shell": false,
     },
     Function (code, signal),
   ],

--- a/src/run/test/handle-reporter.ts
+++ b/src/run/test/handle-reporter.ts
@@ -339,7 +339,7 @@ t.test('custom cli program reporter', async t => {
       t.strictSame(reporterCalled, [], 'did not use @tapjs/reporter')
       const cmd = '/bin/test-exe-reporter'
       const opt = {
-        shell: true,
+        shell: false,
         stdio: ['pipe', 'inherit', 'inherit'],
       }
       t.strictSame(spawnCalled, [[cmd, args, opt]], 'spawn called')
@@ -377,7 +377,7 @@ t.test('custom cli program reporter to file', async t => {
       t.strictSame(reporterCalled, [], 'did not use @tapjs/reporter')
       const cmd = '/bin/test-exe-reporter'
       const opt = {
-        shell: true,
+        shell: false,
         stdio: ['pipe', 'pipe', 'inherit'],
       }
       t.strictSame(spawnCalled, [[cmd, args, opt]], 'spawn called')

--- a/src/run/test/list.ts
+++ b/src/run/test/list.ts
@@ -152,10 +152,10 @@ t.test('list some test files', async t => {
       },
     )
 
-    // it MAY end up sorted once, randomly, but likely not 10 times in a row
+    // it MAY end up sorted once, randomly, but likely not 100 times in a row
     let log: string[] = []
     let sorted: string[] = []
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 100; i++) {
       await list(['src/*.spec.js', 'test/*.*js'], mainConfig.config)
       log = unsortedLog()
       sorted = [

--- a/src/run/test/npm.ts
+++ b/src/run/test/npm.ts
@@ -47,7 +47,7 @@ const mockFail = {
       ___: SpawnOptions,
       cb: Cleanup,
     ) {
-      cb(1, 'SIGTERM')
+      cb(1, 'SIGTERM', {})
     },
   },
 }
@@ -82,7 +82,7 @@ const mockPass = {
       ___: SpawnOptions,
       cb: Cleanup,
     ) {
-      cb(0, null)
+      cb(0, null, {})
     },
   },
 }
@@ -237,4 +237,24 @@ t.test('npm installs go to workspace root', async t => {
     )
     t.match(failSpawn(), [])
   })
+})
+
+t.test('uses the correct npm exe for the platform', async t => {
+  const expect = {
+    win32: 'npm.cmd',
+    posix: 'npm',
+  }
+  for (const [platform, exe] of Object.entries(expect)) {
+    t.test(platform, async t => {
+      t.intercept(process, 'platform', { value: platform })
+      t.equal(
+        (
+          await t.mockImport<typeof import('../src/npm.js')>(
+            '../src/npm.js',
+          )
+        ).npmExe,
+        exe,
+      )
+    })
+  }
 })

--- a/src/stack/src/parse.ts
+++ b/src/stack/src/parse.ts
@@ -99,7 +99,7 @@ export const parseCallSiteLine = (line: string): Compiled => {
 }
 
 const parseCallSiteLine_ = (line: string): Compiled => {
-  line = line.replace(/^\s+at /, '')
+  line = line.replace(/^\s+at (async )?/, '')
 
   // just a lineref, nothing else:
   const bm = line.match(bareLineRefRe) as

--- a/src/stack/tap-snapshots/test/parse.ts.test.cjs
+++ b/src/stack/tap-snapshots/test/parse.ts.test.cjs
@@ -350,6 +350,15 @@ Object {
 }
 `
 
+exports[`test/parse.ts > TAP > node:internal/modules/esm/loader:123:456 > must match snapshot 1`] = `
+Object {
+  "columnNumber": 456,
+  "fileName": "node:internal/modules/esm/loader",
+  "lineNumber": 123,
+  [Symbol(compiled call site line)]: true,
+}
+`
+
 exports[`test/parse.ts > TAP > Object.[foo] (__dirname/generate-parse-fixture.js:420:69) > must match snapshot 1`] = `
 Object {
   "columnNumber": 69,

--- a/src/stack/test/parse.ts
+++ b/src/stack/test/parse.ts
@@ -56,10 +56,11 @@ const cases = [
   '    at Object.[some (weird) [<symbolism>]] [as foo] (__dirname/generate-parse-fixture.js:420:69)',
   '    at Foo.get stringStack (test/fixtures/eval-call-site.ts:17:33)',
   '    at Object.a (s) d [f] (__dirname/generate-parse-fixture.js:420:69)',
+  '    at async node:internal/modules/esm/loader:123:456',
 ]
 
 for (const c of cases) {
-  const d = c.replace(/^\s+at /, '')
+  const d = c.replace(/^\s+at /, '').replace(/^async /, '')
   t.test(d, t => {
     const cp = parseCallSiteLine(c)
     t.matchSnapshot(cp)


### PR DESCRIPTION
Refactored the way child processes are spawned when installing plugins or handling custom reporters to avoid using `shell: true`. The current implementation in `npm.ts` and `handle-reporter.ts` relies on the shell to resolve executables and arguments, which can lead to unexpected behavior or potential argument injection if input contains special shell characters.

Switching to direct execution ensures that arguments are passed as a clean array to the target process. For the `npm` wrapper, a platform-specific check has been added to correctly resolve `npm.cmd` on Windows, maintaining compatibility without the overhead or risks of a shell environment. These changes improve the robustness of the CLI when dealing with various plugin names and reporter arguments. I verified that using `which(reporter)` already provides the absolute path, so bypassing the shell is safe and efficient.