### PR TITLE
Fix formatting for JSON output paths in documentation.

### DIFF
--- a/src/docs/content/dot-tap-folder.md
+++ b/src/docs/content/dot-tap-folder.md
@@ -92,8 +92,8 @@ When generating coverage reports, the files generated go in here.
 | `lcov`                     | `.tap/report/lcov.info`, `.tap/report/lcov-report/index.html` |
 | `clover`                   | `.tap/report/clover.xml`                                      |
 | `cobertura`                | `.tap/report/cobertura-coverage.xml`                          |
-| `json`                     | `.tap/report/coverage-final.json                              |
-| `json-summary`             | `.tap/report/coverage-summary.json                            |
+| `json`                     | `.tap/report/coverage-final.json`                             |
+| `json-summary`             | `.tap/report/coverage-summary.json`                           |
 | `lcovonly`                 | `.tap/report/lcov.info`                                       |
 
 ## `.tap/fixtures`


### PR DESCRIPTION
Two entries in the table in the "`.tap/report`" section of `src/docs/content/dot-tap-folder.md` where missing backticks <code>`</code>, which caused incorrect rendering:

![screenshot](https://github.com/user-attachments/assets/76ab70de-ab16-469d-9154-6f211c8913e5)

This MR fixes that by adding the missing backticks.