### PR TITLE
parser: Fix homepage URL in package.json

### DIFF
--- a/src/parser/package.json
+++ b/src/parser/package.json
@@ -60,7 +60,7 @@
     "url": "git+ssh://git@github.com/tapjs/tapjs.git",
     "path": "src/parser"
   },
-  "homepage": "https://github.com/tapjs/tapjs/src/parser#readme",
+  "homepage": "https://github.com/tapjs/tapjs/tree/main/src/parser#readme",
   "bugs": {
     "url": "https://github.com/tapjs/tapjs/issues"
   },


### PR DESCRIPTION
https://www.npmjs.com/package/tap-parser points to https://github.com/tapjs/tapjs/src/parser#readme which is a 404 Not Found.